### PR TITLE
improve typing on createComponentInstance function

### DIFF
--- a/src/apis/computed.ts
+++ b/src/apis/computed.ts
@@ -33,14 +33,13 @@ export function computed<T>(options: Option<T>['get'] | Option<T>): Ref<T> {
   });
 
   return createRef<T>({
-    get: () => (computedHost as any).$$state,
+    get: () => computedHost.$$state,
     set: (v: T) => {
       if (process.env.NODE_ENV !== 'production' && !set) {
         warn('Computed property was assigned to but it has no setter.', vm!);
         return;
       }
-
-      (computedHost as any).$$state = v;
+      computedHost.$$state = v;
     },
   });
 }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,7 +1,16 @@
-import Vue, { ComponentOptions, VueConstructor } from 'vue';
+import Vue, { VueConstructor } from 'vue';
+import {
+  DefaultMethods,
+  DefaultComputed,
+  DefaultProps,
+  DefaultData,
+  ThisTypedComponentOptionsWithRecordProps,
+  ThisTypedComponentOptionsWithArrayProps,
+} from 'vue/types/options';
 import { ComponentInstance } from './component';
 import { currentVue, getCurrentVM } from './runtimeContext';
 import { assert } from './utils';
+import { CombinedVueInstance } from 'vue/types/vue';
 
 export function ensureCurrentVMInFn(hook: string): ComponentInstance {
   const vm = getCurrentVM();
@@ -11,14 +20,33 @@ export function ensureCurrentVMInFn(hook: string): ComponentInstance {
   return vm!;
 }
 
-export function createComponentInstance<V extends Vue = Vue>(
+// props array
+export function createComponentInstance<
+  V extends Vue = Vue,
+  Data = DefaultData<V>,
+  Methods = DefaultMethods<V>,
+  Computed = DefaultComputed,
+  PropsNames extends string = ''
+>(
   Ctor: VueConstructor<V>,
-  options: ComponentOptions<V> = {}
+  options?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropsNames>
+): CombinedVueInstance<V, Data, Methods, Computed, Record<PropsNames, unknown>>;
+// typed props
+export function createComponentInstance<
+  V extends Vue = Vue,
+  Data = DefaultData<V>,
+  Methods = DefaultMethods<V>,
+  Computed = DefaultComputed,
+  Props = DefaultProps
+>(
+  Ctor: VueConstructor<V>,
+  options: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props> = {}
 ) {
   const silent = Ctor.config.silent;
   Ctor.config.silent = true;
   const vm = new Ctor(options);
   Ctor.config.silent = silent;
+
   return vm;
 }
 


### PR DESCRIPTION
`createComponentInstance` returns a Vue instance that was passed in the first argument, this change allows to get the typing right when we pass the options.

I'm using the same types in `vue/types/options`.

NOTE: I'm not entirely sure about this