### PR TITLE
Add a simple codesandbox link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@
 
 # Navigation
 
+- [Codesandbox](#Codesandbox)
 - [Installation](#Installation)
 - [Usage](#Usage)
 - [TypeScript](#TypeScript)
 - [Limitations](#Limitations)
 - [API](https://vue-composition-api-rfc.netlify.com/api.html)
 - [Changelog](https://github.com/vuejs/composition-api/blob/master/CHANGELOG.md)
+
+# Codesandbox
+
+Here is a very minimal codesandbox template (with TS) if you wish to play with it online:
+https://codesandbox.io/s/vue-3-composition-api-n7lvn
 
 # Installation
 


### PR DESCRIPTION
I reckon having a codesandbox link can encourage people to go and play with it without all the hassle of setting up the repo.

https://codesandbox.io/s/vue-3-composition-api-n7lvn