### PR TITLE
improve prop typings when using setup(props)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,19 @@
 import Vue, { VueConstructor } from 'vue';
-import { Data, SetupFunction, SetupContext } from './component';
+import { SetupFunction, SetupContext } from './component';
 import { currentVue } from './runtimeContext';
 import { install } from './install';
 import { mixin } from './setup';
 
 declare module 'vue/types/options' {
-  interface ComponentOptions<V extends Vue> {
-    setup?: SetupFunction<Data, Data>;
+  interface ComponentOptions<
+    V extends Vue,
+    Data = DefaultData<V>,
+    Methods = DefaultMethods<V>,
+    Computed = DefaultComputed,
+    PropsDef = PropsDefinition<DefaultProps>,
+    Props = DefaultProps
+  > {
+    setup?: SetupFunction<Props, Data>;
   }
 }
 

--- a/test/setup.spec.ts
+++ b/test/setup.spec.ts
@@ -1,0 +1,79 @@
+import { VueConstructor } from 'vue';
+const Vue: VueConstructor = require('vue/dist/vue.common.js');
+import { ref } from '../src';
+
+describe('setup', () => {
+  it('should works', () => {
+    const vm = new Vue({
+      setup() {
+        return {
+          a: ref(1),
+        };
+      },
+    }).$mount();
+
+    expect(vm.a).toBe(1);
+  });
+
+  it('should receive props as first params', () => {
+    let props: any | undefined;
+    new Vue({
+      props: ['a'],
+      setup(_props) {
+        props = _props;
+        _props.a;
+        return {};
+      },
+      propsData: {
+        a: 1,
+      },
+    }).$mount();
+    expect(props.a).toBe(1);
+  });
+
+  it('should receive typed props as first params', () => {
+    let props: any | undefined;
+    new Vue({
+      props: {
+        a: String,
+      },
+      setup(_props) {
+        props = _props;
+        const aStr: string = _props.a;
+        return {
+          aStr,
+        };
+      },
+      propsData: {
+        a: '1',
+      },
+    }).$mount();
+    expect(props.a).toBe('1');
+  });
+
+  it('should have access to props', () => {
+    const Test = Vue.extend({
+      props: ['a'],
+      setup(props) {
+        return {
+          b: props.a,
+        };
+      },
+    });
+    const vm = new Vue({
+      template: `<test ref="test" :a="1"></test>`,
+      components: { Test },
+    }).$mount();
+    expect((vm.$refs.test as any).b).toBe(1);
+  });
+
+  it('this should be undefined', () => {
+    const vm = new Vue({
+      template: '<div></div>',
+      setup() {
+        expect(this).toBe(global);
+      },
+    }).$mount();
+    expect(vm).toBeDefined();
+  });
+});


### PR DESCRIPTION
Allow getting typings on the props: 


```ts
export default Vue.extend({

  props: {
      myProp: String
  },

  setup(pp, context) {
    const myprop = ref(pp.myProp)
    return {
      myprop
    }
  }
})

```

![image](https://user-images.githubusercontent.com/4620458/64075968-e2a3a380-ccb6-11e9-89ec-940707eed747.png)
