### PR TITLE
fix(src/install.ts): fix possible if-condition mistakes

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -26,7 +26,7 @@ function mergeData(to: AnyObject, from?: AnyObject): Object {
     } else if (
       toVal !== fromVal &&
       (isPlainObject(toVal) && !isRef(toVal)) &&
-      (isPlainObject(fromVal) && !isRef(toVal))
+      (isPlainObject(fromVal) && !isRef(fromVal))
     ) {
       mergeData(toVal, fromVal);
     }


### PR DESCRIPTION
Hey liximomo, I've been learning your implementations of new Vue.js RFCs, and I thought it is a really awesome way to provide a new feature on old Vue.js architecture.
But I've found in your `src/install.ts` when provided a duplicate if condition of `!isRef(toVal)`.
I guess it should be `!isRef(fromVal)`, was it a correct fix?