### PR TITLE
docs: added limitation documentation of using reactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ b.list[1].count === 1; // true
 
 ### ***Using*** `reactive` will mutate the origin object
 
-This is an limitation of using Vue.observable in Vue 2.
-> Vue 3 it will return an new proxy object.
+This is an limitation of using `Vue.observable` in Vue 2.
+> Vue 3 will return an new proxy object.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ b.list.push(
 b.list[1].count === 1; // true
 ```
 
+### ***Using*** `reactive` will mutate the origin object
+
+This is an limitation of using Vue.observable in Vue 2.
+> Vue 3 it will return an new proxy object.
+
 ---
 
 ## `watch()` API

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,6 +167,11 @@ b.list.push(
 b.list[1].count === 1; // true
 ```
 
+### ***Using*** `reactive` will mutate the origin object
+
+This is an limitation of using Vue.observable in Vue 2.
+> Vue 3 it will return an new proxy object.
+
 ---
 
 ## `watch()` API

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,10 +167,10 @@ b.list.push(
 b.list[1].count === 1; // true
 ```
 
-### ***Using*** `reactive` will mutate the origin object
+### `reactive` 会返回一个修改过的原始的对象
 
-This is an limitation of using Vue.observable in Vue 2.
-> Vue 3 it will return an new proxy object.
+此行为与 Vue 2 中的 `Vue.observable` 一致
+> Vue 3 中会返回一个新的的代理对象.
 
 ---
 


### PR DESCRIPTION
Currently using `reactive` will change the original object passed to the function, this is not an expected behaviour, since the [doc](https://vue-composition-api-rfc.netlify.com/api.html#reactive):

> Takes an object and returns a reactive proxy of the original. This is equivalent to 2.x's Vue.observable().
> ... the returned proxy is ***not*** equal to the original object....

But currently when using `reactive` ***will*** change the original object.

***NOTE*** if someone could translate the chinese docs pls

Issue: #111 