### PR TITLE
Fix: make __ob__ unenumerable and enable createComponent() accept tuple props.

### DIFF
--- a/src/component/componentProps.ts
+++ b/src/component/componentProps.ts
@@ -1,8 +1,10 @@
 import { Data } from './component';
 
-export type ComponentPropsOptions<P = Data> = {
-  [K in keyof P]: Prop<P[K], true | false> | null;
-};
+export type ComponentPropsOptions<P = Data> =
+  | {
+      [K in keyof P]: Prop<P[K], true | false> | null;
+    }
+  | readonly string[];
 
 type Prop<T, Required extends boolean> = PropOptions<T, Required> | PropType<T>;
 
@@ -14,6 +16,8 @@ export interface PropOptions<T = any, Required extends boolean = false> {
 }
 
 export type PropType<T> = PropConstructor<T> | PropConstructor<T>[];
+
+type PropKeys<O extends readonly string[]> = O[number];
 
 type PropConstructor<T> = { new (...args: any[]): T & object } | { (): T };
 
@@ -39,7 +43,9 @@ type InferPropType<T> = T extends null
         : T;
 
 // prettier-ignore
-export type ExtractPropTypes<O, MakeDefaultRequired extends boolean = true> = {
+export type ExtractPropTypes<O, MakeDefaultRequired extends boolean = true> = O extends readonly string[] ? {
+  [K in PropKeys<O>]: any;
+} : {
   readonly [K in RequiredKeys<O, MakeDefaultRequired>]: InferPropType<O[K]>;
 } & {
   readonly [K in OptionalKeys<O, MakeDefaultRequired>]?: InferPropType<O[K]>;

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -152,7 +152,12 @@ export function nonReactive<T = any>(obj: T): T {
   }
 
   // set the vue observable flag at obj
-  (obj as any).__ob__ = (observe({}) as any).__ob__;
+  Object.defineProperty(obj, '__ob__', {
+    value: (observe({}) as any).__ob__,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
   // mark as nonReactive
   def(obj, NonReactiveIdentifierKey, NonReactiveIdentifier);
 

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -1,5 +1,5 @@
 const Vue = require('vue/dist/vue.common.js');
-const { ref, computed, createElement: h } = require('../src');
+const { ref, computed, createElement: h, createComponent } = require('../src');
 
 describe('setup', () => {
   beforeEach(() => {
@@ -274,6 +274,24 @@ describe('setup', () => {
         expect(vm.$el.textContent).toBe('2, 3');
       })
       .then(done);
+  });
+
+  it("should put a unenumerable '__ob__' for non-reactive object", () => {
+    const clone = obj => JSON.parse(JSON.stringify(obj));
+    const componentSetup = jest.fn(props => {
+      const internalOptions = clone(props.options);
+      return { internalOptions };
+    });
+    const ExternalComponent = {
+      props: ['options'],
+      setup: componentSetup,
+    };
+    new Vue({
+      components: { ExternalComponent },
+      setup: () => ({ options: {} }),
+      template: `<external-component ref="comp" :options="options"></external-component>`,
+    }).$mount();
+    expect(componentSetup).toReturn();
   });
 
   it('current vue should exist in nested setup call', () => {

--- a/test/types/createComponent.spec.ts
+++ b/test/types/createComponent.spec.ts
@@ -131,6 +131,17 @@ describe('createComponent', () => {
     expect.assertions(2);
   });
 
+  it('should accept tuple props', () => {
+    const App = createComponent({
+      props: ['p1', 'p2'] as const,
+      setup(props) {
+        props.p1;
+        props.p2;
+      },
+    });
+    new Vue(App);
+  });
+
   describe('compatible with vue router', () => {
     it('RouteConfig.component', () => {
       new Router({


### PR DESCRIPTION
Current `nonReactive` will put a `__ob__` property to avoid reactivity in `observe` function, but in some clone functions, recursive references will throw error or make stack overflow such as `JSON.stringify` and `vue-echarts`.