### PR TITLE
fix: binding context vm when using function without parentheses 

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -193,6 +193,10 @@ export function mixin(Vue: VueConstructor) {
           if (isReactive(bindingValue)) {
             bindingValue = ref(bindingValue);
           } else {
+            // bind function to the vm, this will make `this` = vm
+            if (isFunction(bindingValue)){
+              bindingValue = bindingValue.bind(vm);
+            }
             // a non-reactive should not don't get reactivity
             bindingValue = ref(nonReactive(bindingValue));
           }

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -355,4 +355,46 @@ describe('setup', () => {
       })
       .then(done);
   });
+
+  describe('Bindings', ()=>{
+    it('should bind the vm when calling with parentesis', async ()=>{
+      let context = null;
+      const contextFunction = jest.fn(function (){
+        context = this
+      });
+
+      const vm = new Vue({
+        template: '<div><button @click="contextFunction()"/></div>',
+        setup() {
+          return {
+            contextFunction
+          }
+        }
+      }).$mount();
+  
+      await vm.$el.querySelector('button').click();
+      expect(contextFunction).toBeCalled();
+      expect(context.$el).toBe(vm.$el);
+    });
+
+    it('should bind the vm when calling without parentesis', async ()=>{
+      let context = null;
+      const contextFunction = jest.fn(function (){
+        context = this
+      });
+
+      const vm = new Vue({
+        template: '<div><button @click="contextFunction"/></div>',
+        setup() {
+          return {
+            contextFunction
+          }
+        }
+      }).$mount();
+  
+      await vm.$el.querySelector('button').click();
+      expect(contextFunction).toBeCalled();
+      expect(context.$el).toBe(vm.$el);
+    });
+  })
 });

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -356,8 +356,8 @@ describe('setup', () => {
       .then(done);
   });
 
-  describe('Bindings', ()=>{
-    it('should bind the vm when calling with parentesis', async ()=>{
+  describe('Methods', () => {
+    it('binds methods when calling with parenthesis', async ()=>{
       let context = null;
       const contextFunction = jest.fn(function (){
         context = this
@@ -374,10 +374,10 @@ describe('setup', () => {
   
       await vm.$el.querySelector('button').click();
       expect(contextFunction).toBeCalled();
-      expect(context.$el).toBe(vm.$el);
+      expect(context).toBe(vm);
     });
 
-    it('should bind the vm when calling without parentesis', async ()=>{
+    it('binds methods when calling without parenthesis', async () => {
       let context = null;
       const contextFunction = jest.fn(function (){
         context = this
@@ -394,7 +394,7 @@ describe('setup', () => {
   
       await vm.$el.querySelector('button').click();
       expect(contextFunction).toBeCalled();
-      expect(context.$el).toBe(vm.$el);
+      expect(context).toBe(vm);
     });
   })
 });


### PR DESCRIPTION
Binding function to the vm context.

Fixes: #144