### PR TITLE
fix: make __ob__ unenumerable

### DIFF
--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -152,12 +152,7 @@ export function nonReactive<T = any>(obj: T): T {
   }
 
   // set the vue observable flag at obj
-  Object.defineProperty(obj, '__ob__', {
-    value: (observe({}) as any).__ob__,
-    enumerable: false,
-    configurable: true,
-    writable: true,
-  });
+  def(obj, '__ob__', (observe({}) as any).__ob__);
   // mark as nonReactive
   def(obj, NonReactiveIdentifierKey, NonReactiveIdentifier);
 

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -152,7 +152,12 @@ export function nonReactive<T = any>(obj: T): T {
   }
 
   // set the vue observable flag at obj
-  (obj as any).__ob__ = (observe({}) as any).__ob__;
+  Object.defineProperty(obj, '__ob__', {
+    value: (observe({}) as any).__ob__,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
   // mark as nonReactive
   def(obj, NonReactiveIdentifierKey, NonReactiveIdentifier);
 

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -1,5 +1,5 @@
 const Vue = require('vue/dist/vue.common.js');
-const { ref, computed, createElement: h } = require('../src');
+const { ref, computed, createElement: h, createComponent } = require('../src');
 
 describe('setup', () => {
   beforeEach(() => {
@@ -274,6 +274,24 @@ describe('setup', () => {
         expect(vm.$el.textContent).toBe('2, 3');
       })
       .then(done);
+  });
+
+  it("should put a unenumerable '__ob__' for non-reactive object", () => {
+    const clone = obj => JSON.parse(JSON.stringify(obj));
+    const componentSetup = jest.fn(props => {
+      const internalOptions = clone(props.options);
+      return { internalOptions };
+    });
+    const ExternalComponent = {
+      props: ['options'],
+      setup: componentSetup,
+    };
+    new Vue({
+      components: { ExternalComponent },
+      setup: () => ({ options: {} }),
+      template: `<external-component :options="options"></external-component>`,
+    }).$mount();
+    expect(componentSetup).toReturn();
   });
 
   it('current vue should exist in nested setup call', () => {

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -1,5 +1,5 @@
 const Vue = require('vue/dist/vue.common.js');
-const { ref, computed, createElement: h, createComponent } = require('../src');
+const { ref, computed, createElement: h } = require('../src');
 
 describe('setup', () => {
   beforeEach(() => {


### PR DESCRIPTION
Make `__ob__` unenumerable to avoid stack overflow while some code traverse properties of reactive object internally like `vue-echarts` and `JSON.stringify()`.