### PR TITLE
fix: avoid accessing undeclared instance fields on type level

### DIFF
--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -65,15 +65,15 @@ interface ComponentOptionsWithProps<
   setup?: SetupFunction<Props, RawBindings>;
 }
 
-interface ComponentOptionsWithoutProps<Props = never, RawBindings = Data> {
+interface ComponentOptionsWithoutProps<Props = unknown, RawBindings = Data> {
   props?: undefined;
   setup?: SetupFunction<Props, RawBindings>;
 }
 
 // overload 1: object format with no props
 export function createComponent<RawBindings>(
-  options: ComponentOptionsWithoutProps<never, RawBindings>
-): VueProxy<never, RawBindings>;
+  options: ComponentOptionsWithoutProps<unknown, RawBindings>
+): VueProxy<unknown, RawBindings>;
 // overload 2: object format with object props declaration
 // see `ExtractPropTypes` in ./componentProps.ts
 export function createComponent<

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -22,8 +22,8 @@ export type ComponentRenderProxy<P = {}, S = {}, PublicProps = P> = {
   S;
 
 // for Vetur and TSX support
-type VueConstructorProxy<PropsOptions, RawBindings> = {
-  new (): ComponentRenderProxy<
+type VueConstructorProxy<PropsOptions, RawBindings> = VueConstructor & {
+  new (...args: any[]): ComponentRenderProxy<
     ExtractPropTypes<PropsOptions>,
     UnwrapRef<RawBindings>,
     ExtractPropTypes<PropsOptions, false>

--- a/test/types/createComponent.spec.ts
+++ b/test/types/createComponent.spec.ts
@@ -89,7 +89,7 @@ describe('createComponent', () => {
     const App = createComponent({
       setup(props, ctx) {
         isTypeEqual<SetupContext, typeof ctx>(true);
-        isTypeEqual<never, typeof props>(true);
+        isTypeEqual<unknown, typeof props>(true);
         return () => null;
       },
     });


### PR DESCRIPTION
fix #187 

As `never` is bottom type, `ExtractPropTypes<never>` is resolved as a type that accepts any field access:

```
ExtractPropTypes<never> = {
    readonly [x: string]: undefined;
    readonly [x: number]: undefined;
}
```

which is included in intersections of `ComponentRenderProxy` type, consists of `VueProxy` instance type.

The default type of `Props` seems to be `unknown`. As it is top type, `ExtractPropTypes<unknown>` will be `{}` which is expected type in this case.