### PR TITLE
Branding Ref so types with a value property aren't incorrectly unwrapped.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marketdial/composition-api",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Provide logic composition capabilities for Vue.",
   "keywords": [
     "vue",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vue/composition-api",
+  "name": "@marketdial/composition-api",
   "version": "0.3.4",
   "description": "Provide logic composition capabilities for Vue.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@marketdial/composition-api",
-  "version": "0.3.5",
+  "name": "@vue/composition-api",
+  "version": "0.3.4",
   "description": "Provide logic composition capabilities for Vue.",
   "keywords": [
     "vue",

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -6,7 +6,7 @@ import { reactive } from './reactive';
 
 type BailTypes = Function | Map<any, any> | Set<any> | WeakMap<any, any> | WeakSet<any>;
 
-const _refBrand: unique symbol = Symbol();
+declare const _refBrand: unique symbol;
 export interface Ref<T> {
   readonly [_refBrand]: true;
   value: T;
@@ -94,10 +94,6 @@ class RefImpl<T> implements Ref<T> {
     proxy(this, 'value', {
       get,
       set,
-    });
-    Object.defineProperty(this, _refBrand, {
-      enumerable: false,
-      value: true,
     });
   }
 }

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -7,9 +7,8 @@ import { reactive } from './reactive';
 type BailTypes = Function | Map<any, any> | Set<any> | WeakMap<any, any> | WeakSet<any>;
 
 const _refBrand: unique symbol = Symbol();
-type _refBrand = typeof _refBrand;
 export interface Ref<T> {
-  readonly _refBrand: _refBrand;
+  readonly [_refBrand]: true;
   value: T;
 }
 
@@ -89,12 +88,16 @@ interface RefOption<T> {
   set?(x: T): void;
 }
 class RefImpl<T> implements Ref<T> {
-  readonly _refBrand: _refBrand = _refBrand;
+  readonly [_refBrand]!: true;
   public value!: T;
   constructor({ get, set }: RefOption<T>) {
     proxy(this, 'value', {
       get,
       set,
+    });
+    Object.defineProperty(this, _refBrand, {
+      enumerable: false,
+      value: true,
     });
   }
 }

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -6,7 +6,10 @@ import { reactive } from './reactive';
 
 type BailTypes = Function | Map<any, any> | Set<any> | WeakMap<any, any> | WeakSet<any>;
 
+const _refBrand: unique symbol = Symbol();
+type _refBrand = typeof _refBrand;
 export interface Ref<T> {
+  readonly _refBrand: _refBrand;
   value: T;
 }
 
@@ -86,6 +89,7 @@ interface RefOption<T> {
   set?(x: T): void;
 }
 class RefImpl<T> implements Ref<T> {
+  readonly _refBrand: _refBrand = _refBrand;
   public value!: T;
   constructor({ get, set }: RefOption<T>) {
     proxy(this, 'value', {
@@ -134,7 +138,7 @@ export function isRef<T>(value: any): value is Ref<T> {
 
 // prettier-ignore
 type Refs<Data> = {
-  [K in keyof Data]: Data[K] extends Ref<infer V> 
+  [K in keyof Data]: Data[K] extends Ref<infer V>
     ? Ref<V>
     : Ref<Data[K]>
 }


### PR DESCRIPTION
I'm running into the problem where this type declared in my codebase:

```ts
export type GenericOption<T> = { name: string, value: T }
```
incorrectly `extends` `Ref`, which means that `UnwrapRef` is unwrapping it to `T` which isn't correct.

Here's a playground demonstrating this:
https://www.typescriptlang.org/play/?ssl=22&ssc=1&pln=22&pc=63#code/MYewdgzgLgBA+gJwKYDMBCCCGYAmAuGAVzAEsBHQpGCATwFsAjEAGxgF4YBlep5gCgCUAKCg0ADlUSoM2HOxiiJIFPGTosuIUgAeYkAlgkwUJAhSZgVAEqoAPABUAfDADeQmB5gB6LzGSYccGYaVWkNfFD1WQBud08AN0xmSgJ7WIBfISEjEzMLa1QAeTEoEnAHZzcPAHMkKEFU2I8IOoB+Pm1UgQJ4kBIcDKFgZkwICBgbFABJOjFmCpgSWeYkOiRjccmFqr8kAKCQqSjcAiOZXHkz8KaYMUIGZhJgGETkpABCRrjQSCgEQmAUH0fBcMFqUAANNQ6jB0gRJsVSuUnAJXHEPFAABYIEAAdxgYCQ+IAoggcQhBHFMpktLp9LBFFQAOLrUxPRFlMALDigsCYNYEaAIIzVKGvFIweywrKMyVIaDyFmE4XADnlbA0Zw6Ey4TZ2DXOVoKf5UAjmZgtIA

If you hover over the `Test` type it displays as `true` right now, but uncommenting the `// readonly _refBrand: _refBrand;` line will make it correctly display as `false`.

I'm assuming that since `isRef` simply does an `instanceof` check that this is safe and won't interfere with the actual unwrapping algorithm, but I'll admit I haven't deeply looked.

I'm looking forward to Vue 3 coming out! I've enjoyed working with this library so far.

fixes #157 
fixes #159