### PR TITLE
refactor: rename createComponent as defineComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ After installing the plugin you can use the [Composition API](https://vue-compos
 
 **This plugin requires TypeScript version >3.5.1. If you are using vetur, make sure to set `vetur.useWorkspaceDependencies` to `true`.**
 
-To let TypeScript properly infer types inside Vue component options, you need to define components with `createComponent`:
+To let TypeScript properly infer types inside Vue component options, you need to define components with `defineComponent`:
 
 ```ts
-import { createComponent } from '@vue/composition-api';
+import { defineComponent } from '@vue/composition-api';
 
-const Component = createComponent({
+const Component = defineComponent({
   // type inference enabled
 });
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,12 +57,12 @@ Vue.use(VueCompositionApi);
 
 **请使用最新版的 TypeScript，如果你使用了 `vetur`，请将 `vetur.useWorkspaceDependencies` 设为 `true`。**
 
-为了让 TypeScript 正确的推导类型，我们必须使用 `createComponent` 来定义组件:
+为了让 TypeScript 正确的推导类型，我们必须使用 `defineComponent` 来定义组件:
 
 ```ts
-import { createComponent } from '@vue/composition-api';
+import { defineComponent } from '@vue/composition-api';
 
-const Component = createComponent({
+const Component = defineComponent({
   // 启用类型推断
 });
 

--- a/src/apis/computed.ts
+++ b/src/apis/computed.ts
@@ -1,6 +1,6 @@
 import { getCurrentVue, getCurrentVM } from '../runtimeContext';
 import { createRef, Ref } from '../reactivity';
-import { createComponentInstance } from '../helper';
+import { defineComponentInstance } from '../helper';
 import { warn } from '../utils';
 
 interface Option<T> {
@@ -25,7 +25,7 @@ export function computed<T>(
     set = options.set;
   }
 
-  const computedHost = createComponentInstance(getCurrentVue(), {
+  const computedHost = defineComponentInstance(getCurrentVue(), {
     computed: {
       $$state: {
         get,

--- a/src/apis/watch.ts
+++ b/src/apis/watch.ts
@@ -1,7 +1,7 @@
 import { ComponentInstance } from '../component';
 import { Ref, isRef } from '../reactivity';
 import { assert, logError, noopFn } from '../utils';
-import { createComponentInstance } from '../helper';
+import { defineComponentInstance } from '../helper';
 import { getCurrentVM, getCurrentVue } from '../runtimeContext';
 import { WatcherPreFlushQueueKey, WatcherPostFlushQueueKey } from '../symbols';
 
@@ -262,7 +262,7 @@ export function watch(
   let vm = getCurrentVM();
   if (!vm) {
     if (!fallbackVM) {
-      fallbackVM = createComponentInstance(getCurrentVue());
+      fallbackVM = defineComponentInstance(getCurrentVue());
     }
     vm = fallbackVM;
   } else if (!hasWatchEnv(vm)) {

--- a/src/component/index.ts
+++ b/src/component/index.ts
@@ -1,6 +1,7 @@
 export {
   Data,
   createComponent,
+  defineComponent,
   SetupFunction,
   SetupContext,
   ComponentInstance,

--- a/src/createElement.ts
+++ b/src/createElement.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import { currentVM, getCurrentVue } from './runtimeContext';
-import { createComponentInstance } from './helper';
+import { defineComponentInstance } from './helper';
 import { warn } from './utils';
 
 type CreateElement = Vue['$createElement'];
@@ -11,7 +11,7 @@ const createElement: CreateElement = function createElement(...args: any) {
   if (!currentVM) {
     warn('`createElement()` has been called outside of render function.');
     if (!fallbackCreateElement) {
-      fallbackCreateElement = createComponentInstance(getCurrentVue()).$createElement;
+      fallbackCreateElement = defineComponentInstance(getCurrentVue()).$createElement;
     }
 
     return fallbackCreateElement.apply(fallbackCreateElement, args);

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -11,7 +11,7 @@ export function ensureCurrentVMInFn(hook: string): ComponentInstance {
   return vm!;
 }
 
-export function createComponentInstance<V extends Vue = Vue>(
+export function defineComponentInstance<V extends Vue = Vue>(
   Ctor: VueConstructor<V>,
   options: ComponentOptions<V> = {}
 ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,13 @@ if (currentVue && typeof window !== 'undefined' && window.Vue) {
 export default plugin;
 export { default as createElement } from './createElement';
 export { SetupContext };
-export { createComponent, ComponentRenderProxy, PropType, PropOptions } from './component';
+export {
+  createComponent,
+  defineComponent,
+  ComponentRenderProxy,
+  PropType,
+  PropOptions,
+} from './component';
 // For getting a hold of the interal instance in setup() - useful for advanced
 // plugins
 export { getCurrentVM as getCurrentInstance } from './runtimeContext';

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -1,7 +1,7 @@
 import { AnyObject } from '../types/basic';
 import { getCurrentVue } from '../runtimeContext';
 import { isPlainObject, def, hasOwn, warn } from '../utils';
-import { isComponentInstance, createComponentInstance } from '../helper';
+import { isComponentInstance, defineComponentInstance } from '../helper';
 import {
   AccessControlIdentifierKey,
   ReactiveIdentifierKey,
@@ -113,7 +113,7 @@ function observe<T>(obj: T): T {
   if (Vue.observable) {
     observed = Vue.observable(obj);
   } else {
-    const vm = createComponentInstance(Vue, {
+    const vm = defineComponentInstance(Vue, {
       data: {
         $$state: obj,
       },


### PR DESCRIPTION
Since Vue `3.0.0-alpha.1`, `createComponent` has been renamed `defineComponent`.
See https://github.com/vuejs/vue-next/commit/1c4cdd841daa2ba9c1ec35068c92f1ae776cacea