### PR TITLE
type: add typing for setup function to support scoped slots

### DIFF
--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -40,9 +40,9 @@ type VueProxy<PropsOptions, RawBindings> = Vue2ComponentOptions<
 > &
   VueConstructorProxy<PropsOptions, RawBindings>;
 
-export interface SetupContext {
+export interface SetupContext<ScopedSlots = Data> {
   readonly attrs: Record<string, string>;
-  readonly slots: { [key: string]: (...args: any[]) => VNode[] };
+  readonly slots: { [K in keyof ScopedSlots]: (props: ScopedSlots[K]) => VNode[] };
   readonly parent: ComponentInstance | null;
   readonly root: ComponentInstance;
   readonly listeners: { [key: string]: Function };
@@ -50,24 +50,25 @@ export interface SetupContext {
   emit(event: string, ...args: any[]): void;
 }
 
-export type SetupFunction<Props, RawBindings> = (
+export type SetupFunction<Props, RawBindings, ScopedSlots = Data> = (
   this: void,
   props: Props,
-  ctx: SetupContext
+  ctx: SetupContext<ScopedSlots>
 ) => RawBindings | (() => VNode | null);
 
 interface ComponentOptionsWithProps<
   PropsOptions = ComponentPropsOptions,
   RawBindings = Data,
-  Props = ExtractPropTypes<PropsOptions>
+  Props = ExtractPropTypes<PropsOptions>,
+  ScopedSlots = Data
 > {
   props?: PropsOptions;
-  setup?: SetupFunction<Props, RawBindings>;
+  setup?: SetupFunction<Props, RawBindings, ScopedSlots>;
 }
 
-interface ComponentOptionsWithoutProps<Props = never, RawBindings = Data> {
+interface ComponentOptionsWithoutProps<Props = never, RawBindings = Data, ScopedSlots = Data> {
   props?: undefined;
-  setup?: SetupFunction<Props, RawBindings>;
+  setup?: SetupFunction<Props, RawBindings, ScopedSlots>;
 }
 
 // overload 1: object format with no props

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { mixin } from './setup';
 
 declare module 'vue/types/options' {
   interface ComponentOptions<V extends Vue> {
-    setup?: SetupFunction<Data, Data>;
+    setup?: SetupFunction<Data, Data, Data>;
   }
 }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -167,7 +167,7 @@ export function mixin(Vue: VueConstructor) {
     // resolve scopedSlots and slots to functions
     resolveScopedSlots(vm, ctx.slots);
 
-    let binding: ReturnType<SetupFunction<Data, Data>> | undefined | null;
+    let binding: ReturnType<SetupFunction<Data, Data, Data>> | undefined | null;
     activateCurrentInstance(vm, () => {
       binding = setup(props, ctx);
     });


### PR DESCRIPTION
Add typings to SetupContext to support scoped slots appropriately.
It is now possible to pass a type into the setupContext generic to increase type
safety.