### PR TITLE
Handle non-reactive nulls (#231)

### DIFF
--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -22,7 +22,7 @@ function isNonReactive(obj: any): boolean {
 
 export function isReactive(obj: any): boolean {
   return (
-    obj !== null &&
+    obj != null &&
     hasOwn(obj, ReactiveIdentifierKey) &&
     obj[ReactiveIdentifierKey] === ReactiveIdentifier
   );
@@ -86,7 +86,7 @@ export function defineAccessControl(target: AnyObject, key: any, val?: any) {
     get: function getterHandler() {
       const value = getter ? getter.call(target) : val;
       // if the key is equal to RefKey, skip the unwrap logic
-      if (key != RefKey && isRef(value)) {
+      if (key !== RefKey && isRef(value)) {
         return value.value;
       } else {
         return value;

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -86,7 +86,7 @@ export function defineAccessControl(target: AnyObject, key: any, val?: any) {
     get: function getterHandler() {
       const value = getter ? getter.call(target) : val;
       // if the key is equal to RefKey, skip the unwrap logic
-      if (key !== RefKey && isRef(value)) {
+      if (key != RefKey && isRef(value)) {
         return value.value;
       } else {
         return value;

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -21,7 +21,11 @@ function isNonReactive(obj: any): boolean {
 }
 
 export function isReactive(obj: any): boolean {
-  return hasOwn(obj, ReactiveIdentifierKey) && obj[ReactiveIdentifierKey] === ReactiveIdentifier;
+  return (
+    obj !== null &&
+    hasOwn(obj, ReactiveIdentifierKey) &&
+    obj[ReactiveIdentifierKey] === ReactiveIdentifier
+  );
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,8 +36,8 @@ export function def(obj: Object, key: string, val: any, enumerable?: boolean) {
   });
 }
 
-export function hasOwn(obj: Object | any[], key: string): boolean {
-  return obj !== null && Object.hasOwnProperty.call(obj, key);
+export function hasOwn(obj: Object, key: string): boolean {
+  return Object.hasOwnProperty.call(obj, key);
 }
 
 export function assert(condition: any, msg: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,13 +2,15 @@ import Vue from 'vue';
 
 const toString = (x: any) => Object.prototype.toString.call(x);
 
-export function isNative (Ctor: any): boolean {
-  return typeof Ctor === 'function' && /native code/.test(Ctor.toString())
+export function isNative(Ctor: any): boolean {
+  return typeof Ctor === 'function' && /native code/.test(Ctor.toString());
 }
 
 export const hasSymbol =
-  typeof Symbol !== 'undefined' && isNative(Symbol) &&
-  typeof Reflect !== 'undefined' && isNative(Reflect.ownKeys)
+  typeof Symbol !== 'undefined' &&
+  isNative(Symbol) &&
+  typeof Reflect !== 'undefined' &&
+  isNative(Reflect.ownKeys);
 
 export const noopFn: any = (_: any) => _;
 
@@ -34,9 +36,8 @@ export function def(obj: Object, key: string, val: any, enumerable?: boolean) {
   });
 }
 
-const hasOwnProperty = Object.prototype.hasOwnProperty;
 export function hasOwn(obj: Object | any[], key: string): boolean {
-  return hasOwnProperty.call(obj, key);
+  return obj !== null && Object.hasOwnProperty.call(obj, key);
 }
 
 export function assert(condition: any, msg: string) {

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -36,10 +36,12 @@ describe('setup', () => {
       setup() {
         return {
           a: undefined,
+          b: 'foobar',
         };
       },
     }).$mount();
     expect(vm.a).toBe(undefined);
+    expect(vm.b).toBe('foobar');
   });
 
   it('should be overrided by data option of plain object', () => {

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -20,6 +20,17 @@ describe('setup', () => {
     expect(vm.a).toBe(1);
   });
 
+  it('should work with non reactive null', () => {
+    const vm = new Vue({
+      setup() {
+        return {
+          a: null,
+        };
+      },
+    }).$mount();
+    expect(vm.a).toBe(null);
+  });
+
   it('should be overrided by data option of plain object', () => {
     const vm = new Vue({
       setup() {

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -30,6 +30,17 @@ describe('setup', () => {
     }).$mount();
     expect(vm.a).toBe(null);
   });
+  
+  it('should work with non reactive undefined', () => {
+    const vm = new Vue({
+      setup() {
+        return {
+          a: undefined,
+        };
+      },
+    }).$mount();
+    expect(vm.a).toBe(null);
+  });
 
   it('should be overrided by data option of plain object', () => {
     const vm = new Vue({

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -39,7 +39,7 @@ describe('setup', () => {
         };
       },
     }).$mount();
-    expect(vm.a).toBe(null);
+    expect(vm.a).toBe(undefined);
   });
 
   it('should be overrided by data option of plain object', () => {


### PR DESCRIPTION
Fix for #231 - Ensure non reactive nulls are supported.

```
// 'this' cannot be set to null.
Object.hasOwnProperty.call(null, ''); // TypeError Cannot convert undefined or null to object

// Not an Object...
(null).hasOwnProperty('') // TypeError: Cannot read property 'hasOwnProperty' of null
```

Solution would be to check if the obj is null.