### PR TITLE
types(reactivity): fix corner case on UnwrapRef

### DIFF
--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -6,6 +6,11 @@ import { reactive } from './reactive';
 
 type BailTypes = Function | Map<any, any> | Set<any> | WeakMap<any, any> | WeakSet<any>;
 
+// corner case when use narrows type
+// Ex. type RelativePath = string & { __brand: unknown }
+// RelativePath extends object -> true
+type BaseTypes = string | number | boolean;
+
 export interface Ref<T> {
   value: T;
 }
@@ -16,63 +21,63 @@ export interface Ref<T> {
 // practical use cases...
 export type UnwrapRef<T> = T extends Ref<infer V>
   ? UnwrapRef2<V>
-  : T extends BailTypes
+  : T extends BailTypes | BaseTypes
       ? T // bail out on types that shouldn't be unwrapped
       : T extends object ? { [K in keyof T]: UnwrapRef2<T[K]> } : T
 
 // prettier-ignore
 type UnwrapRef2<T> = T extends Ref<infer V>
   ? UnwrapRef3<V>
-  : T extends BailTypes
+  : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef3<T[K]> } : T
 
 // prettier-ignore
 type UnwrapRef3<T> = T extends Ref<infer V>
   ? UnwrapRef4<V>
-  : T extends BailTypes
+  : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef4<T[K]> } : T
 
 // prettier-ignore
 type UnwrapRef4<T> = T extends Ref<infer V>
   ? UnwrapRef5<V>
-  : T extends BailTypes
+  : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef5<T[K]> } : T
 
 // prettier-ignore
 type UnwrapRef5<T> = T extends Ref<infer V>
   ? UnwrapRef6<V>
-  : T extends BailTypes
+  : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef6<T[K]> } : T
 
 // prettier-ignore
 type UnwrapRef6<T> = T extends Ref<infer V>
   ? UnwrapRef7<V>
-  : T extends BailTypes
+  : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef7<T[K]> } : T
 
 // prettier-ignore
 type UnwrapRef7<T> = T extends Ref<infer V>
   ? UnwrapRef8<V>
-  : T extends BailTypes
+  : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef8<T[K]> } : T
 
 // prettier-ignore
 type UnwrapRef8<T> = T extends Ref<infer V>
   ? UnwrapRef9<V>
-  : T extends BailTypes
+  : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef9<T[K]> } : T
 
 // prettier-ignore
 type UnwrapRef9<T> = T extends Ref<infer V>
   ? UnwrapRef10<V>
-  : T extends BailTypes
+  : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef10<T[K]> } : T
 


### PR DESCRIPTION
Same as vuejs/vue-next#614

We need special string or number types sometimes.
Ex. RelativePath, AbsolutePath

```typescript
type AbsolutePath = string & { __brand: unknown }
function readFile (path: AbsolutePath) {
  // do some thing
}
function getAbsolutePath (path: string) {
  if (path.startWith('file://')) return path as AbsolutePath
}
```

I use it for safe use translation keys,
but code is broken when passing UnwrapRef on vetur template interpolation.