### PR TITLE
Remove --save

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 **npm**
 
 ```bash
-npm install @vue/composition-api --save
+npm install @vue/composition-api
 ```
 
 **yarn**


### PR DESCRIPTION
npm by default installs packages as dependencies.

Works in npm-cli>=5(Which came years ago!)