### PR TITLE
WIP fix(types): ensure correct oldValue typing based on lazy option

### DIFF
--- a/test/apis/watch.spec.js
+++ b/test/apis/watch.spec.js
@@ -34,7 +34,7 @@ describe('api/watch', () => {
     }).then(done);
   });
 
-  it('basic usage(value warpper)', done => {
+  it('basic usage(value wrapper)', done => {
     const vm = new Vue({
       setup() {
         const a = ref(1);


### PR DESCRIPTION
- [ ] adjust test cases and add new ones
- [ ] correct vm.$watch calls, which are currently not matching anymore
```
No overload matches this call.
  Overload 1 of 2, '(expOrFn: string, callback: (this: CombinedVueInstance<Vue, object, object, object, Record<never, any>>, n: any, o: any) => void, options?: WatchOptions | undefined): () => void', gave the following error.
    Das Argument vom Typ "() => void" kann dem Parameter vom Typ "string" nicht zugewiesen werden.
  Overload 2 of 2, '(expOrFn: (this: CombinedVueInstance<Vue, object, object, object, Record<never, any>>) => void, callback: (this: CombinedVueInstance<Vue, object, object, object, Record<...>>, n: void, o: void) => void, options?: WatchOptions | undefined): () => void', gave the following error.
```

- [x] corrected typos
- [x] adjust method headers and add typings

#253 