### PR TITLE
fix: the parent setup should be called first

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -7,7 +7,7 @@ import { VueConstructor } from 'vue';
 /**
  * Helper that recursively merges two data objects together.
  */
-function mergeData(to: AnyObject, from?: AnyObject): Object {
+function mergeData(from: AnyObject, to: AnyObject): Object {
   if (!from) return to;
   let key: any;
   let toVal: any;
@@ -28,7 +28,7 @@ function mergeData(to: AnyObject, from?: AnyObject): Object {
       (isPlainObject(toVal) && !isRef(toVal)) &&
       (isPlainObject(fromVal) && !isRef(fromVal))
     ) {
-      mergeData(toVal, fromVal);
+      mergeData(fromVal, toVal);
     }
   }
   return to;
@@ -45,8 +45,8 @@ export function install(Vue: VueConstructor, _install: (Vue: VueConstructor) => 
   Vue.config.optionMergeStrategies.setup = function(parent: Function, child: Function) {
     return function mergedSetupFn(props: any, context: any) {
       return mergeData(
-        typeof child === 'function' ? child(props, context) || {} : {},
-        typeof parent === 'function' ? parent(props, context) || {} : {}
+        typeof parent === 'function' ? parent(props, context) || {} : {},
+        typeof child === 'function' ? child(props, context) || {} : {}
       );
     };
   };

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -1,5 +1,5 @@
 const Vue = require('vue/dist/vue.common.js');
-const { ref, computed, createElement: h } = require('../src');
+const { ref, computed, createElement: h, provide, inject } = require('../src');
 
 describe('setup', () => {
   beforeEach(() => {
@@ -144,14 +144,21 @@ describe('setup', () => {
   });
 
   it('should merge result properly', () => {
+    const injectKey = Symbol('foo');
     const A = Vue.extend({
       setup() {
+        provide(injectKey, 'foo');
         return { a: 1 };
       },
     });
     const Test = Vue.extend({
       extends: A,
-      setup() {},
+      setup() {
+        const injectVal = inject(injectKey);
+        return {
+          injectVal,
+        };
+      },
     });
     let vm = new Test({
       setup() {
@@ -160,6 +167,7 @@ describe('setup', () => {
     });
     expect(vm.a).toBe(1);
     expect(vm.b).toBe(2);
+    expect(vm.injectVal).toBe('foo');
     // no instance data
     vm = new Test();
     expect(vm.a).toBe(1);


### PR DESCRIPTION
The parent setup should be called first, otherwise inject cannot get the provide data of the parent class