### PR TITLE
Fix(computed): destroy helper vm of computed to prevent memleak (fix #270)

### DIFF
--- a/src/apis/computed.ts
+++ b/src/apis/computed.ts
@@ -34,6 +34,8 @@ export function computed<T>(
     },
   });
 
+  vm && vm.$on('hook:destroyed', () => computedHost.$destroy());
+
   return createRef<T>({
     get: () => (computedHost as any).$$state,
     set: (v: T) => {


### PR DESCRIPTION
We use a Vue instancefor each computed(), as a helper to actually use Vue's `computed:` option.

However we don't destroy it when the host component is destroyed. When the computed property references reactive state that's external to the host instance, the helper instance stays in memory as it's watching the external state.

Properly destroying witht the host component fixes this.
 
fix #270