### PR TITLE
type: Added Element type to ref BailTypes

### DIFF
--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -4,7 +4,7 @@ import { proxy, isPlainObject } from '../utils';
 import { HasDefined } from '../types/basic';
 import { reactive } from './reactive';
 
-type BailTypes = Function | Map<any, any> | Set<any> | WeakMap<any, any> | WeakSet<any>;
+type BailTypes = Function | Map<any, any> | Set<any> | WeakMap<any, any> | WeakSet<any> | Element;
 
 export interface Ref<T> {
   value: T;


### PR DESCRIPTION
Suppose I want to return ref to the template to be filled with my html element:
`const element = ref<HTMLElement>(null);`

Then I wrap it with reactive:
```
const state = reactive({
    element,
    ...someOtherProps
})
```

Element goes through `UnwrapRef` and its type inference is broken.