### PR TITLE
fix: isReactive & isNonReactive throws on null value

### DIFF
--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -16,12 +16,18 @@ const NonReactiveIdentifier = {};
 
 function isNonReactive(obj: any): boolean {
   return (
-    hasOwn(obj, NonReactiveIdentifierKey) && obj[NonReactiveIdentifierKey] === NonReactiveIdentifier
+    obj != null &&
+    hasOwn(obj, NonReactiveIdentifierKey) &&
+    obj[NonReactiveIdentifierKey] === NonReactiveIdentifier
   );
 }
 
 export function isReactive(obj: any): boolean {
-  return hasOwn(obj, ReactiveIdentifierKey) && obj[ReactiveIdentifierKey] === ReactiveIdentifier;
+  return (
+    obj != null &&
+    hasOwn(obj, ReactiveIdentifierKey) &&
+    obj[ReactiveIdentifierKey] === ReactiveIdentifier
+  );
 }
 
 /**


### PR DESCRIPTION
suppose you have a component: 

```
{
    setup() {
        return {
            foo: null
        }
    }
}
```

If your property is `null` or `undefined` a function `isReactive()` throws error, because it tries to call `hasOwnProperty()` on `null` value.

I suppose the same case is for the `isNonReactive()` function, so I made fixes in both.

Some call stack for the reference:
![image](https://user-images.githubusercontent.com/2473784/76786246-2d01f300-67b7-11ea-82bd-1f5ccf94e691.png)
