### PR TITLE
fix: unwrapping refs for generic and nullable types

### DIFF
--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -19,70 +19,70 @@ export interface Ref<T> {
 // Recursively unwraps nested value bindings.
 // Unfortunately TS cannot do recursive types, but this should be enough for
 // practical use cases...
-export type UnwrapRef<T> = T extends Ref<infer V>
+export type UnwrapRef<T> = T extends Ref<infer V | null | undefined>
   ? UnwrapRef2<V>
   : T extends BailTypes | BaseTypes
       ? T // bail out on types that shouldn't be unwrapped
       : T extends object ? { [K in keyof T]: UnwrapRef2<T[K]> } : T
 
 // prettier-ignore
-type UnwrapRef2<T> = T extends Ref<infer V>
+type UnwrapRef2<T> = T extends Ref<infer V | null | undefined>
   ? UnwrapRef3<V>
   : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef3<T[K]> } : T
 
 // prettier-ignore
-type UnwrapRef3<T> = T extends Ref<infer V>
+type UnwrapRef3<T> = T extends Ref<infer V | null | undefined>
   ? UnwrapRef4<V>
   : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef4<T[K]> } : T
 
 // prettier-ignore
-type UnwrapRef4<T> = T extends Ref<infer V>
+type UnwrapRef4<T> = T extends Ref<infer V | null | undefined>
   ? UnwrapRef5<V>
   : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef5<T[K]> } : T
 
 // prettier-ignore
-type UnwrapRef5<T> = T extends Ref<infer V>
+type UnwrapRef5<T> = T extends Ref<infer V | null | undefined>
   ? UnwrapRef6<V>
   : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef6<T[K]> } : T
 
 // prettier-ignore
-type UnwrapRef6<T> = T extends Ref<infer V>
+type UnwrapRef6<T> = T extends Ref<infer V | null | undefined>
   ? UnwrapRef7<V>
   : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef7<T[K]> } : T
 
 // prettier-ignore
-type UnwrapRef7<T> = T extends Ref<infer V>
+type UnwrapRef7<T> = T extends Ref<infer V | null | undefined>
   ? UnwrapRef8<V>
   : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef8<T[K]> } : T
 
 // prettier-ignore
-type UnwrapRef8<T> = T extends Ref<infer V>
+type UnwrapRef8<T> = T extends Ref<infer V | null | undefined>
   ? UnwrapRef9<V>
   : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef9<T[K]> } : T
 
 // prettier-ignore
-type UnwrapRef9<T> = T extends Ref<infer V>
+type UnwrapRef9<T> = T extends Ref<infer V | null | undefined>
   ? UnwrapRef10<V>
   : T extends BailTypes | BaseTypes
       ? T
       : T extends object ? { [K in keyof T]: UnwrapRef10<T[K]> } : T
 
 // prettier-ignore
-type UnwrapRef10<T> = T extends Ref<infer V>
+type UnwrapRef10<T> = T extends Ref<infer V | null | undefined>
   ? V // stop recursion
   : T
 


### PR DESCRIPTION
Suppose we have some generic type:
`type Foo<T> = Ref<T | null>;`

Now let us define a new type: 
`type X<T> = UnwrapRef<Foo<T>>;`

We would expect that it will be simply `UnwrapRef2<T | null>` but in fact no:
![image](https://user-images.githubusercontent.com/2473784/76957678-86ccff00-6916-11ea-80b8-bf26b881b1a5.png)

The reason is here:
![image](https://user-images.githubusercontent.com/2473784/76957727-a06e4680-6916-11ea-84b6-df4b5b6a3563.png)

TS seems to threat it as `UnwrapRef2<T> | UnwrapRef2<null>`, and because `null` goes all the way through this ifology, it ends up as  `UnwrapRef2<T> | null`. 

It happens in cases, when type is not known beforehand, so in any library / generic approach.

After this fix, type will be much more complicated:
![image](https://user-images.githubusercontent.com/2473784/76958000-27232380-6917-11ea-9147-39c7accfbf29.png)
