### PR TITLE
fix(watch): update watch options from lazy to immediate

### DIFF
--- a/test/apis/state.spec.js
+++ b/test/apis/state.spec.js
@@ -24,9 +24,13 @@ describe('api/ref', () => {
   it('should be reactive', done => {
     const a = ref(1);
     let dummy;
-    watch(a, () => {
-      dummy = a.value;
-    });
+    watch(
+      a,
+      () => {
+        dummy = a.value;
+      },
+      { immediate: true }
+    );
     expect(dummy).toBe(1);
     a.value = 2;
     waitForUpdate(() => {
@@ -44,7 +48,7 @@ describe('api/ref', () => {
       () => {
         dummy = a.value.count;
       },
-      { deep: true }
+      { deep: true, immediate: true }
     );
     expect(dummy).toBe(1);
     a.value.count = 2;
@@ -102,7 +106,8 @@ describe('api/toRefs', () => {
       () => state,
       () => {
         dummy = state.foo;
-      }
+      },
+      { immediate: true }
     );
     const stateAsRefs = toRefs(state);
     expect(dummy).toBe(1);
@@ -128,7 +133,7 @@ describe('api/toRefs', () => {
       bar: 2,
     };
 
-    watch(() => state, spy, { flush: 'sync', lazy: true });
+    watch(() => state, spy, { flush: 'sync' });
     const stateAsRefs = toRefs(state);
 
     expect(stateAsRefs.foo.value).toBe(1);
@@ -155,7 +160,7 @@ describe('unwrapping', () => {
       () => {
         dummy = obj.a;
       },
-      { deep: true, flush: 'sync' }
+      { deep: true, flush: 'sync', immediate: true }
     );
     expect(dummy).toBe(0);
     expect(obj.a).toBe(0);
@@ -220,7 +225,7 @@ describe('unwrapping', () => {
         dummy1 = obj.a;
         dummy2 = obj.b.c;
       },
-      { deep: true, flush: 'sync' }
+      { deep: true, flush: 'sync', immediate: true }
     );
     expect(dummy1).toBe(1);
     expect(dummy2).toBe(1);
@@ -250,7 +255,7 @@ describe('unwrapping', () => {
         dummy1 = obj.a;
         dummy2 = obj.b.c;
       },
-      { deep: true, flush: 'sync' }
+      { deep: true, flush: 'sync', immediate: true }
     );
     expect(dummy1).toBe(1);
     expect(dummy2).toBe(1);
@@ -281,7 +286,7 @@ describe('unwrapping', () => {
       () => {
         dummy = obj.a.foo;
       },
-      { deep: true, flush: 'sync' }
+      { deep: true, flush: 'sync', immediate: true }
     );
     expect(dummy).toBe(undefined);
     set(obj.a, 'foo', count);
@@ -306,7 +311,7 @@ describe('unwrapping', () => {
       () => {
         dummy = obj.a.b;
       },
-      { deep: true, lazy: true, flush: 'sync' }
+      { deep: true, flush: 'sync' }
     );
     expect(dummy).toBeUndefined();
     const replacedRef = ref(2);
@@ -341,7 +346,7 @@ describe('unwrapping', () => {
       () => {
         dummy = state.list[0].count;
       },
-      { lazy: true, flush: 'sync' }
+      { flush: 'sync' }
     );
     expect(dummy).toBeUndefined();
     const a = ref(0);

--- a/test/apis/watch.spec.js
+++ b/test/apis/watch.spec.js
@@ -16,7 +16,7 @@ describe('api/watch', () => {
     const vm = new Vue({
       setup() {
         const a = ref(1);
-        watch(a, spy);
+        watch(a, spy, { immediate: true });
         return {
           a,
         };
@@ -38,7 +38,7 @@ describe('api/watch', () => {
     const vm = new Vue({
       setup() {
         const a = ref(1);
-        watch(a, (n, o) => spy(n, o), { flush: 'pre' });
+        watch(a, (n, o) => spy(n, o), { flush: 'pre', immediate: true });
 
         return {
           a,
@@ -60,7 +60,11 @@ describe('api/watch', () => {
     const vm = new Vue({
       setup() {
         const a = ref(1);
-        watch(() => a.value, (n, o) => spy(n, o));
+        watch(
+          () => a.value,
+          (n, o) => spy(n, o),
+          { immediate: true }
+        );
 
         return {
           a,
@@ -102,11 +106,11 @@ describe('api/watch', () => {
     }).then(done);
   });
 
-  it('with option: lazy', done => {
+  it('with option: immediate=false', done => {
     const vm = new Vue({
       setup() {
         const a = ref(1);
-        watch(a, (n, o) => spy(n, o), { lazy: true });
+        watch(a, (n, o) => spy(n, o));
 
         return {
           a,
@@ -125,7 +129,7 @@ describe('api/watch', () => {
     const vm = new Vue({
       setup() {
         const a = ref({ b: 1 });
-        watch(a, (n, o) => spy(n, o), { lazy: true, deep: true });
+        watch(a, (n, o) => spy(n, o), { deep: true });
 
         return {
           a,
@@ -147,19 +151,15 @@ describe('api/watch', () => {
       .then(done);
   });
 
-  it('should flush after render (lazy=true)', done => {
+  it('should flush after render (immediate=false)', done => {
     let rerenderedText;
     const vm = new Vue({
       setup() {
         const a = ref(1);
-        watch(
-          a,
-          (newVal, oldVal) => {
-            spy(newVal, oldVal);
-            rerenderedText = vm.$el.textContent;
-          },
-          { lazy: true }
-        );
+        watch(a, (newVal, oldVal) => {
+          spy(newVal, oldVal);
+          rerenderedText = vm.$el.textContent;
+        });
         return {
           a,
         };
@@ -177,17 +177,23 @@ describe('api/watch', () => {
     }).then(done);
   });
 
-  it('should flush after render (lazy=false)', done => {
+  it('should flush after render (immediate=true)', done => {
     let rerenderedText;
     var vm = new Vue({
       setup() {
         const a = ref(1);
-        watch(a, (newVal, oldVal) => {
-          spy(newVal, oldVal);
-          if (vm) {
-            rerenderedText = vm.$el.textContent;
+        watch(
+          a,
+          (newVal, oldVal) => {
+            spy(newVal, oldVal);
+            if (vm) {
+              rerenderedText = vm.$el.textContent;
+            }
+          },
+          {
+            immediate: true,
           }
-        });
+        );
         return {
           a,
         };
@@ -216,7 +222,7 @@ describe('api/watch', () => {
             spy(newVal, oldVal);
             expect(vm.$el.textContent).toBe('1');
           },
-          { lazy: true, flush: 'pre' }
+          { flush: 'pre' }
         );
         return {
           a,
@@ -237,7 +243,7 @@ describe('api/watch', () => {
     const vm = new Vue({
       setup() {
         const a = ref(1);
-        watch(a, (n, o) => spy(n, o), { lazy: true, flush: 'sync' });
+        watch(a, (n, o) => spy(n, o), { flush: 'sync' });
         return {
           a,
         };
@@ -260,7 +266,7 @@ describe('api/watch', () => {
     const vm = new Vue({
       setup() {
         const a = ref(1);
-        watch(a, (n, o) => spy(n, o), { lazy: true });
+        watch(a, (n, o) => spy(n, o));
 
         return {
           数据: a,
@@ -282,7 +288,7 @@ describe('api/watch', () => {
     new Vue({
       setup() {
         const count = ref(0);
-        watch(count, (n, o) => spy(n, o), { flush: 'sync' });
+        watch(count, (n, o) => spy(n, o), { flush: 'sync', immediate: true });
         count.value++;
       },
     });
@@ -305,11 +311,11 @@ describe('api/watch', () => {
         watchEffect(() => { void x.value; result.push('post effect'); }, { flush: 'post' });
 
         // prettier-ignore
-        watch(x, () => { result.push('sync callback') }, { flush: 'sync' })
+        watch(x, () => { result.push('sync callback') }, { flush: 'sync', immediate: true })
         // prettier-ignore
-        watch(x, () => { result.push('pre callback') }, { flush: 'pre' })
+        watch(x, () => { result.push('pre callback') }, { flush: 'pre', immediate: true })
         // prettier-ignore
-        watch(x, () => { result.push('post callback') }, { flush: 'post' })
+        watch(x, () => { result.push('post callback') }, { flush: 'post', immediate: true })
 
         const inc = () => {
           result.push('before inc');
@@ -411,7 +417,7 @@ describe('api/watch', () => {
         setup() {
           obj1 = reactive({ a: 1 });
           obj2 = reactive({ a: 2 });
-          watch([() => obj1.a, () => obj2.a], (n, o) => spy(n, o));
+          watch([() => obj1.a, () => obj2.a], (n, o) => spy(n, o), { immediate: true });
           return {
             obj1,
             obj2,
@@ -439,12 +445,12 @@ describe('api/watch', () => {
         .then(done);
     });
 
-    it('basic usage(lazy=false, flush=none-sync)', done => {
+    it('basic usage(immediate=true, flush=none-sync)', done => {
       const vm = new Vue({
         setup() {
           const a = ref(1);
           const b = ref(1);
-          watch([a, b], (n, o) => spy(n, o), { lazy: false, flush: 'post' });
+          watch([a, b], (n, o) => spy(n, o), { immediate: true, flush: 'post' });
 
           return {
             a,
@@ -470,12 +476,12 @@ describe('api/watch', () => {
         .then(done);
     });
 
-    it('basic usage(lazy=true, flush=none-sync)', done => {
+    it('basic usage(immediate=false, flush=none-sync)', done => {
       const vm = new Vue({
         setup() {
           const a = ref(1);
           const b = ref(1);
-          watch([a, b], (n, o) => spy(n, o), { lazy: true, flush: 'post' });
+          watch([a, b], (n, o) => spy(n, o), { immediate: false, flush: 'post' });
 
           return {
             a,
@@ -499,12 +505,12 @@ describe('api/watch', () => {
         .then(done);
     });
 
-    it('basic usage(lazy=false, flush=sync)', () => {
+    it('basic usage(immediate=true, flush=sync)', () => {
       const vm = new Vue({
         setup() {
           const a = ref(1);
           const b = ref(1);
-          watch([a, b], (n, o) => spy(n, o), { lazy: false, flush: 'sync' });
+          watch([a, b], (n, o) => spy(n, o), { immediate: true, flush: 'sync' });
 
           return {
             a,
@@ -524,12 +530,12 @@ describe('api/watch', () => {
       expect(spy).toHaveBeenNthCalledWith(4, [3, 3], [3, 1]);
     });
 
-    it('basic usage(lazy=true, flush=sync)', () => {
+    it('basic usage(immediate=false, flush=sync)', () => {
       const vm = new Vue({
         setup() {
           const a = ref(1);
           const b = ref(1);
-          watch([a, b], (n, o) => spy(n, o), { lazy: true, flush: 'sync' });
+          watch([a, b], (n, o) => spy(n, o), { immediate: false, flush: 'sync' });
 
           return {
             a,
@@ -552,7 +558,11 @@ describe('api/watch', () => {
   describe('Out of setup', () => {
     it('should work', done => {
       const obj = reactive({ a: 1 });
-      watch(() => obj.a, (n, o) => spy(n, o));
+      watch(
+        () => obj.a,
+        (n, o) => spy(n, o),
+        { immediate: true }
+      );
       expect(spy).toHaveBeenLastCalledWith(1, undefined);
       obj.a = 2;
       waitForUpdate(() => {
@@ -638,10 +648,14 @@ describe('api/watch', () => {
       const id = ref(1);
       const spy = jest.fn();
       const cleanup = jest.fn();
-      const stop = watch(id, (value, oldValue, onCleanup) => {
-        spy(value);
-        onCleanup(cleanup);
-      });
+      const stop = watch(
+        id,
+        (value, oldValue, onCleanup) => {
+          spy(value);
+          onCleanup(cleanup);
+        },
+        { immediate: true }
+      );
 
       expect(spy).toHaveBeenCalledWith(1);
       stop();
@@ -676,13 +690,17 @@ describe('api/watch', () => {
     it('work with callback ', done => {
       const id = ref(1);
       const promises = [];
-      watch(id, (newVal, oldVal, onCleanup) => {
-        const val = getAsyncValue(newVal);
-        promises.push(val);
-        onCleanup(() => {
-          val.cancel();
-        });
-      });
+      watch(
+        id,
+        (newVal, oldVal, onCleanup) => {
+          const val = getAsyncValue(newVal);
+          promises.push(val);
+          onCleanup(() => {
+            val.cancel();
+          });
+        },
+        { immediate: true }
+      );
       id.value = 2;
       waitForUpdate()
         .thenWaitFor(async next => {


### PR DESCRIPTION
This aligns with the latest RFC: https://vue-composition-api-rfc.netlify.com/api.html#watch

`lazy` is renamed to `immediate` and default to false. 

This is a BREAKING CHANGE. Not sure if we should make backward compatible and raise warnings.

Resolves #266 