### PR TITLE
fix: avoid including Function type in inferred props type

### DIFF
--- a/src/component/componentProps.ts
+++ b/src/component/componentProps.ts
@@ -30,14 +30,17 @@ type RequiredKeys<T, MakeDefaultRequired> = {
 
 type OptionalKeys<T, MakeDefaultRequired> = Exclude<keyof T, RequiredKeys<T, MakeDefaultRequired>>;
 
+// We wrap every conditional type with tuple as we don't want to distribute it.
+// About distributive conditional types: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types
+// Related issue: https://github.com/vuejs/composition-api/issues/291
 // prettier-ignore
-type InferPropType<T> = T extends null
+type InferPropType<T> = [T] extends [null]
   ? any // null & true would fail to infer
-  : T extends { type: null }
+  : [T] extends [{ type: null }]
     ? any // somehow `ObjectConstructor` when inferred from { (): T } becomes `any`
-    : T extends ObjectConstructor | { type: ObjectConstructor }
+    : [T] extends [ObjectConstructor | { type: ObjectConstructor }]
       ? { [key: string]: any }
-      : T extends Prop<infer V, true | false>
+      : [T] extends [Prop<infer V, true | false>]
         ? V
         : T;
 

--- a/test/types/defineComponent.spec.ts
+++ b/test/types/defineComponent.spec.ts
@@ -1,4 +1,11 @@
-import { createComponent, defineComponent, createElement as h, ref, SetupContext, PropType } from '../../src';
+import {
+  createComponent,
+  defineComponent,
+  createElement as h,
+  ref,
+  SetupContext,
+  PropType,
+} from '../../src';
 import Router from 'vue-router';
 
 const Vue = require('vue/dist/vue.common.js');
@@ -103,6 +110,24 @@ describe('defineComponent', () => {
     });
     new Vue(App);
     expect.assertions(3);
+  });
+
+  it('custom props type inferred from PropType', () => {
+    interface User {
+      name: string;
+    }
+    const App = defineComponent({
+      props: {
+        user: Object as PropType<User>,
+      },
+      setup(props) {
+        type PropsType = typeof props;
+        isSubType<{ user?: User }, PropsType>(true);
+        isSubType<PropsType, { user?: User }>(true);
+      },
+    });
+    new Vue(App);
+    expect.assertions(2);
   });
 
   it('no props', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
     "downlevelIteration": true,
     "noUnusedLocals": true
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
fix #291 

The issue was caused by [distribution of conditional types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types). The reason there is no issue when we declare props type via `{ type: String }` format is `T extends { type: PropType<infer V, boolean> }` won't be distributed.

The solution is just avoiding distribution in the conditional types in `InferPropType`. To do that, I wrapped all conditional types with tuple.