### PR TITLE
Set default lazy option to true in watch api

### DIFF
--- a/src/apis/watch.ts
+++ b/src/apis/watch.ts
@@ -291,7 +291,7 @@ export function watch(
     callback = null;
   }
 
-  const opts = getWatcherOption(options);
+  const opts = getWatcherOption({ lazy: true, ...options });
   const vm = getWatcherVM();
 
   return createWatcher(vm, source, callback, opts);

--- a/test/apis/state.spec.js
+++ b/test/apis/state.spec.js
@@ -27,7 +27,7 @@ describe('api/ref', () => {
     watch(a, () => {
       dummy = a.value;
     });
-    expect(dummy).toBe(1);
+    expect(dummy).toBeUndefined();
     a.value = 2;
     waitForUpdate(() => {
       expect(dummy).toBe(2);
@@ -46,7 +46,7 @@ describe('api/ref', () => {
       },
       { deep: true }
     );
-    expect(dummy).toBe(1);
+    expect(dummy).toBeUndefined();
     a.value.count = 2;
     waitForUpdate(() => {
       expect(dummy).toBe(2);
@@ -105,7 +105,7 @@ describe('api/toRefs', () => {
       }
     );
     const stateAsRefs = toRefs(state);
-    expect(dummy).toBe(1);
+    expect(dummy).toBeUndefined();
     expect(stateAsRefs.foo.value).toBe(1);
     expect(stateAsRefs.bar.value).toBe(2);
     state.foo++;
@@ -157,7 +157,7 @@ describe('unwrapping', () => {
       },
       { deep: true, flush: 'sync' }
     );
-    expect(dummy).toBe(0);
+    expect(dummy).toBeUndefined();
     expect(obj.a).toBe(0);
     expect(objWrapper.value.a).toBe(0);
     obj.a++;
@@ -222,8 +222,8 @@ describe('unwrapping', () => {
       },
       { deep: true, flush: 'sync' }
     );
-    expect(dummy1).toBe(1);
-    expect(dummy2).toBe(1);
+    expect(dummy1).toBeUndefined();
+    expect(dummy2).toBeUndefined();
     a.value++;
     expect(dummy1).toBe(2);
     expect(dummy2).toBe(2);
@@ -252,8 +252,8 @@ describe('unwrapping', () => {
       },
       { deep: true, flush: 'sync' }
     );
-    expect(dummy1).toBe(1);
-    expect(dummy2).toBe(1);
+    expect(dummy1).toBeUndefined();
+    expect(dummy2).toBeUndefined();
     expect(obj.a).toBe(1);
     expect(obj.b.c).toBe(1);
     obj.a++;


### PR DESCRIPTION
This pull request fixes that `watch` function runs when a source variable has been defined.

https://vue-composition-api-rfc.netlify.com/api.html#watch
> The watch API is the exact equivalent of the 2.x this.$watch (and the corresponding watch option). watch requires watching a specific data source, and applies side effects in a separate callback function. It also is lazy by default - i.e. the callback is only called when the watched source has changed.

As stated in Vue Composition API documents, the callback function passed to `watch` should run only when the source has changed.

vuejs/composition-api always sets `lazy` field of `WatcherOption` to `false` by default,
https://github.com/vuejs/composition-api/blob/master/src/apis/watch.ts#L60

but it should be `true` in `watch`

Resolve #266 