### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ By using the global variable `window.vueCompositionApi`
 # Usage
 
 You must install `@vue/composition-api` via `Vue.use()` before using other APIs:
+Now inside /src/main.js file you will need to add the following code at the top of the page: 
 
 ```js
 import Vue from 'vue';


### PR DESCRIPTION
Without stating that these imports need to be used in the main.js file, users might struggle to know where they go. It took me a while of experimentation and looking around to figure it out. It might be nice to show the difference from a vue 2 file to this new change for an example as well, rather than just saying install.