### PR TITLE
feat: add unref API to match API with vue3

### DIFF
--- a/src/apis/state.ts
+++ b/src/apis/state.ts
@@ -1,1 +1,1 @@
-export { reactive, ref, Ref, isRef, toRefs, set } from '../reactivity';
+export { reactive, ref, Ref, isRef, toRefs, set, unref } from '../reactivity';

--- a/src/reactivity/index.ts
+++ b/src/reactivity/index.ts
@@ -1,3 +1,3 @@
 export { reactive, isReactive, nonReactive } from './reactive';
-export { ref, isRef, Ref, createRef, UnwrapRef, toRefs } from './ref';
+export { ref, isRef, Ref, createRef, UnwrapRef, toRefs, unref } from './ref';
 export { set } from './set';

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -132,6 +132,10 @@ export function isRef<T>(value: any): value is Ref<T> {
   return value instanceof RefImpl;
 }
 
+export function unref<T>(ref: T): T extends Ref<infer V> ? V : T {
+  return isRef(ref) ? (ref.value as any) : ref;
+}
+
 // prettier-ignore
 type Refs<Data> = {
   [K in keyof Data]: Data[K] extends Ref<infer V> 

--- a/test/apis/state.spec.js
+++ b/test/apis/state.spec.js
@@ -1,5 +1,5 @@
 const Vue = require('vue/dist/vue.common.js');
-const { reactive, ref, watch, set, toRefs, computed } = require('../../src');
+const { reactive, ref, watch, set, toRefs, computed, unref } = require('../../src');
 
 describe('api/ref', () => {
   it('should work with array', () => {
@@ -328,6 +328,12 @@ describe('unwrapping', () => {
 
     expect(state.list[0]).toBe(a);
     expect(state.list[0].value).toBe(0);
+  });
+
+  it('should unrwap ref', () => {
+    expect(unref(0)).toBe(0);
+    expect(unref(ref(0))).toBe(0);
+    expect(unref({ value: 1 })).toStrictEqual({ value: 1 });
   });
 
   it('should now unwrap plain object when using set at Array', () => {


### PR DESCRIPTION
Same implementation as vue-next 

https://github.com/vuejs/vue-next/blob/a51b05267231fb1770d6fc727bc276475c21d27f/packages/reactivity/src/ref.ts#L69-L71

```ts
export function unref<T>(ref: T): T extends Ref<infer V> ? V : T {
  return isRef(ref) ? (ref.value as any) : ref
}
```