### PR TITLE
fix(type): fix incorrect ref unwrap

### DIFF
--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -12,7 +12,7 @@ type BailTypes = Function | Map<any, any> | Set<any> | WeakMap<any, any> | WeakS
 type BaseTypes = string | number | boolean;
 
 declare const _refBrand: unique symbol;
-export interface Ref<T> {
+export interface Ref<T = any> {
   readonly [_refBrand]: true;
   value: T;
 }

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -1,7 +1,6 @@
 import { Data } from '../component';
 import { RefKey } from '../symbols';
 import { proxy, isPlainObject, warn } from '../utils';
-import { HasDefined } from '../types/basic';
 import { reactive, isReactive, shallowReactive } from './reactive';
 import { ComputedRef } from '../apis/computed';
 
@@ -79,26 +78,10 @@ export function createRef<T>(options: RefOption<T>) {
   return Object.seal(new RefImpl<T>(options));
 }
 
-type RefValue<T> = T extends Ref<infer V> ? V : UnwrapRef<T>;
-
-export function ref<T extends object>(value: T): T extends Ref ? T : Ref<UnwrapRef<T>>;
-export function ref<T>(value: T): Ref<UnwrapRef<T>>;
-// without init value, explicit typed: a = ref<{ a: number }>()
-// typeof a will be Ref<{ a: number } | undefined>
+export function ref<T extends object>(raw: T): T extends Ref ? T : Ref<UnwrapRef<T>>;
+export function ref<T>(raw: T): Ref<UnwrapRef<T>>;
 export function ref<T = any>(): Ref<T | undefined>;
-// with null as init value: a = ref<{ a: number }>(null);
-// typeof a will be Ref<{ a: number } | null>
-export function ref<T = null>(raw: null): Ref<T | null>;
-// with init value: a = ref({ a: ref(0) })
-// typeof a will be Ref<{ a: number }>
-export function ref<S, T = unknown, R = HasDefined<S> extends true ? S : RefValue<T>>(
-  raw: T
-): Ref<R>;
-// implementation
-export function ref(raw?: any): any {
-  // if (isRef(raw)) {
-  //   return {} as any;
-  // }
+export function ref(raw?: unknown) {
   if (isRef(raw)) {
     return raw;
   }

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -112,6 +112,8 @@ export function createRef<T>(options: RefOption<T>) {
 
 type RefValue<T> = T extends Ref<infer V> ? V : UnwrapRef<T>;
 
+export function ref<T extends object>(value: T): T extends Ref ? T : Ref<UnwrapRef<T>>;
+export function ref<T>(value: T): Ref<UnwrapRef<T>>;
 // without init value, explicit typed: a = ref<{ a: number }>()
 // typeof a will be Ref<{ a: number } | undefined>
 export function ref<T = undefined>(): Ref<T | undefined>;


### PR DESCRIPTION
resolve #257

Align with vue-next
https://github.com/vuejs/vue-next/blob/c6217b4d46cbd3d9e250f2f84de4846d3484c42d/packages/reactivity/src/ref.ts#L30-L37

~I am not sure how these lines work in our current codebase~
```ts
// with init value: a = ref({ a: ref(0) })
// typeof a will be Ref<{ a: number }>
export function ref<S, T = unknown, R = HasDefined<S> extends true ? S : RefValue<T>>(
  raw: T
): Ref<R>;
```
~I kept it for now. But since it's not in vue-next, should we just remove it in order to have better type consistency with vue-next?~

**Edit**: Removed and it's exactly matched to vue-next now.