### PR TITLE
types: Remove Function type from PropType type

### DIFF
--- a/src/component/componentProps.ts
+++ b/src/component/componentProps.ts
@@ -30,6 +30,16 @@ type RequiredKeys<T, MakeDefaultRequired> = {
 
 type OptionalKeys<T, MakeDefaultRequired> = Exclude<keyof T, RequiredKeys<T, MakeDefaultRequired>>;
 
+type ExtractFunctionPropType<
+  T extends Function,
+  TArgs extends Array<any> = any[],
+  TResult = any
+> = T extends (...args: TArgs) => TResult ? T : never;
+
+type ExtractCorrectPropType<T> = T extends Function
+  ? ExtractFunctionPropType<T>
+  : Exclude<T, Function>;
+
 // prettier-ignore
 type InferPropType<T> = T extends null
   ? any // null & true would fail to infer
@@ -38,7 +48,7 @@ type InferPropType<T> = T extends null
     : T extends ObjectConstructor | { type: ObjectConstructor }
       ? { [key: string]: any }
       : T extends Prop<infer V, true | false>
-        ? V
+        ? ExtractCorrectPropType<V>
         : T;
 
 // prettier-ignore

--- a/test/types/defineComponent.spec.ts
+++ b/test/types/defineComponent.spec.ts
@@ -1,11 +1,16 @@
-import { createComponent, defineComponent, createElement as h, ref, SetupContext, PropType } from '../../src';
+import {
+  createComponent,
+  defineComponent,
+  createElement as h,
+  ref,
+  SetupContext,
+  PropType,
+} from '../../src';
 import Router from 'vue-router';
 
 const Vue = require('vue/dist/vue.common.js');
 
-type Equal<Left, Right> = (<U>() => U extends Left ? 1 : 0) extends (<U>() => U extends Right
-  ? 1
-  : 0)
+type Equal<Left, Right> = (<U>() => U extends Left ? 1 : 0) extends <U>() => U extends Right ? 1 : 0
   ? true
   : false;
 
@@ -103,6 +108,28 @@ describe('defineComponent', () => {
     });
     new Vue(App);
     expect.assertions(3);
+  });
+
+  it('custom props type inferred from PropType', () => {
+    interface User {
+      name: string;
+    }
+    const App = defineComponent({
+      props: {
+        user: Object as PropType<User>,
+        func: Function as PropType<() => boolean>,
+        userFunc: Function as PropType<(u: User) => User>,
+      },
+      setup(props) {
+        type PropsType = typeof props;
+        isSubType<{ user?: User }, PropsType>(true);
+        isSubType<PropsType, { user?: User; func?: () => boolean; userFunc?: (u: User) => User }>(
+          true
+        );
+      },
+    });
+    new Vue(App);
+    expect.assertions(2);
   });
 
   it('no props', () => {


### PR DESCRIPTION
fix #291 

Gets the correct type for the prop

Similar to https://github.com/vuejs/composition-api/pull/301

```ts
interface A {
  a: String
}

defineComponent({
  props: {
    a: Object as PropType<A>
  },
  setup(props){
    props.a 
  }
})
```
