### PR TITLE
fix(setup): returning `render` function breaks when extending with an empty object

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -9,6 +9,8 @@ import { VueConstructor } from 'vue'
  */
 function mergeData(from: AnyObject, to: AnyObject): Object {
   if (!from) return to
+  if (!to) return from
+
   let key: any
   let toVal: any
   let fromVal: any
@@ -56,8 +58,8 @@ export function install(
   ) {
     return function mergedSetupFn(props: any, context: any) {
       return mergeData(
-        typeof parent === 'function' ? parent(props, context) || {} : {},
-        typeof child === 'function' ? child(props, context) || {} : {}
+        typeof parent === 'function' ? parent(props, context) || {} : undefined,
+        typeof child === 'function' ? child(props, context) || {} : undefined
       )
     }
   }

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -663,4 +663,16 @@ describe('setup', () => {
       expect(context).toBe(vm)
     })
   })
+
+  it('should work after extending with an undefined setup', () => {
+    const opts = {
+      setup() {
+        return () => h('div', 'Composition-api')
+      },
+    }
+    const Constructor = Vue.extend(opts).extend({})
+
+    const vm = new Vue(Constructor).$mount()
+    expect(vm.$el.textContent).toBe('Composition-api')
+  })
 })


### PR DESCRIPTION
fix https://github.com/vuejs/composition-api/issues/151

Fix the bug when returning render function: `Vue.extend(Comp).extend({}) - vue-test-utils`


The bug is caused because we try to merge the `function` with an empty object.


https://github.com/vuejs/vue-test-utils/pull/1512 can be reopen and merged after we release this
also fix https://github.com/vuejs/vue-test-utils/issues/1484