### PR TITLE
fix: unwrap refs returned by `data`

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -154,6 +154,22 @@ export function mixin(Vue: VueConstructor) {
       }
     }
 
+    const { data } = $options
+    // wrapper the data option, so we can invoke setup before data get resolved
+    $options.data = function wrappedData() {
+      if (setup) {
+        initSetup(vm, vm.$props)
+      }
+      const dataValue =
+        typeof data === 'function'
+          ? (data as (
+              this: ComponentInstance,
+              x: ComponentInstance
+            ) => object).call(vm, vm)
+          : data || {}
+      return unwrapRefProxy(dataValue)
+    }
+
     if (!setup) {
       return
     }
@@ -165,18 +181,6 @@ export function mixin(Vue: VueConstructor) {
         )
       }
       return
-    }
-
-    const { data } = $options
-    // wrapper the data option, so we can invoke setup before data get resolved
-    $options.data = function wrappedData() {
-      initSetup(vm, vm.$props)
-      return typeof data === 'function'
-        ? (data as (
-            this: ComponentInstance,
-            x: ComponentInstance
-          ) => object).call(vm, vm)
-        : data || {}
     }
   }
 

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -744,4 +744,37 @@ describe('setup', () => {
     const vm = new Vue(Constructor).$mount()
     expect(vm.$el.textContent).toBe('Composition-api')
   })
+
+  it('should keep data reactive', async () => {
+    const vm = new Vue({
+      template: `<div>
+        <button id="a" @click="a++">{{a}}</button>
+        <button id="b" @click="b++">{{b}}</button>
+      </div>`,
+      data() {
+        return {
+          a: 1,
+          b: ref(1),
+        }
+      },
+    }).$mount()
+
+    const a = vm.$el.querySelector('#a')
+    const b = vm.$el.querySelector('#b')
+
+    expect(a.textContent).toBe('1')
+    expect(b.textContent).toBe('1')
+
+    a.click()
+    await Vue.nextTick()
+
+    expect(a.textContent).toBe('2')
+    expect(b.textContent).toBe('1')
+
+    b.click()
+    await Vue.nextTick()
+
+    expect(a.textContent).toBe('2')
+    expect(b.textContent).toBe('2')
+  })
 })

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -83,6 +83,19 @@ describe('setup', () => {
     expect(vm.b).toBe(1)
   })
 
+  // #385
+  it('should unwrapRef on data', () => {
+    const vm = new Vue({
+      data() {
+        return {
+          a: ref(1),
+        }
+      },
+      setup() {},
+    }).$mount()
+    expect(vm.a).toBe(1)
+  })
+
   it('should work with `methods` and `data` options', (done) => {
     let calls = 0
     const vm = new Vue({


### PR DESCRIPTION
fix https://github.com/vuejs/composition-api/issues/385

I have a few concerns here, because the unwrapping will create a new `object` everytime: 

```ts
const myObject = { a: 1}

const vm = new Vue({     data() {
        return {
          myObject,
        }
      },
    }).$mount()

vm.myObject === myObject; // this will always be false
```

Not sure how much of a deal breaker this might be, one way to do this is only `unwrap` if there's a `ref` anywhere in the object.

The reason we create a new object is because we don't want to mutate the original object the user is using in the `setup`, because that will lead to some unexpected bugs