### PR TITLE
docs: guide users to use versioned CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install @vue/composition-api
 yarn add @vue/composition-api
 ```
 
-You must install `@vue/composition-api` via `Vue.use()` before you can use the [Composition API](https://composition-api.vuejs.org/) to compose your component.
+You must install `@vue/composition-api` as a plugin via `Vue.use()` before you can use the [Composition API](https://composition-api.vuejs.org/) to compose your component.
 
 ```js
 import Vue from 'vue'
@@ -27,11 +27,15 @@ Vue.use(VueCompositionApi)
 ```
 
 ```js
-// in components
+// use the APIs
 import { ref, reactive } from '@vue/composition-api'
 ```
 
+> :bulb: When you migrate to Vue 3, just replacing `@vue/composition-api` to `vue` and your code should just work.
+
 ### CDN
+
+Add the following lines in your `<head>` to import Vue and `@vue/composition-api`.
 
 <!--cdn-links-start-->
 ```html
@@ -40,7 +44,7 @@ import { ref, reactive } from '@vue/composition-api'
 ```
 <!--cdn-links-end-->
 
-The package will be exposed to global variable `window.vueCompositionApi`
+`@vue/composition-api` will be exposed to global variable `window.vueCompositionApi` and you have to install it before using the APIs.
 
 ```js
 // install the plugin

--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ import { ref, reactive } from '@vue/composition-api'
 
 ### CDN
 
+<!--cdn-links-start-->
 ```html
-<script src="https://unpkg.com/@vue/composition-api/dist/vue-composition-api.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue@2.6"></script>
+<script src="https://cdn.jsdelivr.net/npm/@vue/composition-api@0.6.5"></script>
 ```
+<!--cdn-links-end-->
 
 The package will be exposed to global variable `window.vueCompositionApi`
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,15 +11,6 @@ Vue 2 插件用于提供 Vue 3 中的 **组合式 API**.
 
 ---
 
-# 导航
-
-- [安装](#安装)
-- [使用](#使用)
-- [TypeScript](#TypeScript)
-  - [TSX](#tsx)
-- [限制](#限制)
-- [更新日志](https://github.com/vuejs/composition-api/blob/master/CHANGELOG.md)
-
 # 安装
 
 **npm**
@@ -36,9 +27,12 @@ yarn add @vue/composition-api
 
 **CDN**
 
+<!--cdn-links-start-->
 ```html
-<script src="https://unpkg.com/@vue/composition-api/dist/vue-composition-api.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue@2.6"></script>
+<script src="https://cdn.jsdelivr.net/npm/@vue/composition-api@0.6.5"></script>
 ```
+<!--cdn-links-end-->
 
 通过全局变量 `window.vueCompositionApi` 来使用。
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "main": "dist/vue-composition-api.js",
   "umd:main": "dist/vue-composition-api.umd.js",
+  "browser": "dist/vue-composition-api.umd.js",
   "module": "dist/vue-composition-api.module.js",
   "typings": "dist/index.d.ts",
   "author": {
@@ -31,10 +32,11 @@
     "test": "yarn test-dts && yarn test-unit",
     "test-unit": "cross-env NODE_ENV=test jest",
     "test-dts": "tsc -p ./test-dts/tsconfig.json && yarn build && tsc -p ./test-dts/tsconfig.build.json",
+    "update-readme": "node ./scripts/update-readme.js",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "prepublish": "yarn test",
     "postpublish": "yarn release-gh",
-    "version": "yarn changelog && git add CHANGELOG.md",
+    "version": "yarn changelog && yarn update-readme && git add CHANGELOG.md README.*",
     "release": "yarn version && git push --follow-tags && yarn publish --non-interactive",
     "release-gh": "conventional-github-releaser -p angular"
   },

--- a/scripts/update-readme.js
+++ b/scripts/update-readme.js
@@ -1,0 +1,29 @@
+const { promises: fs } = require('fs')
+const path = require('path')
+const { version } = require('../package.json')
+
+const files = ['../README.md', '../README.zh-CN.md']
+
+const MakeLinks = (version, vueVersion = '2.6') =>
+  `
+\`\`\`html
+<script src="https://cdn.jsdelivr.net/npm/vue@${vueVersion}"></script>
+<script src="https://cdn.jsdelivr.net/npm/@vue/composition-api@${version}"></script>
+\`\`\`
+`
+
+;(async () => {
+  const links = MakeLinks(version)
+
+  for (const file of files) {
+    const filepath = path.resolve(__dirname, file)
+    const raw = await fs.readFile(filepath, 'utf-8')
+
+    const updated = raw.replace(
+      /<!--cdn-links-start-->([\s\S]*)<!--cdn-links-end-->/g,
+      `<!--cdn-links-start-->${links}<!--cdn-links-end-->`
+    )
+
+    await fs.writeFile(filepath, updated, 'utf-8')
+  }
+})()


### PR DESCRIPTION
- Add the `browser` field to `package.json` for CDN services to auto resolving
- Updates the docs for guiding users to use versioned CDN packages
- Add a script to auto-update README on version bumping