### PR TITLE
BREAKING CHANGE: rename createElement to h

### DIFF
--- a/src/apis/computed.ts
+++ b/src/apis/computed.ts
@@ -1,4 +1,4 @@
-import { getCurrentVue, getCurrentVM } from '../runtimeContext'
+import { getCurrentVue, getCurrentInstance } from '../runtimeContext'
 import { createRef, Ref } from '../reactivity'
 import { defineComponentInstance } from '../helper'
 import { warn } from '../utils'
@@ -22,7 +22,7 @@ export function computed<T>(options: Option<T>): WritableComputedRef<T>
 export function computed<T>(
   options: Option<T>['get'] | Option<T>
 ): ComputedRef<T> | WritableComputedRef<T> {
-  const vm = getCurrentVM()
+  const vm = getCurrentInstance()
   let get: Option<T>['get'], set: Option<T>['set'] | undefined
   if (typeof options === 'function') {
     get = options

--- a/src/apis/inject.ts
+++ b/src/apis/inject.ts
@@ -1,7 +1,7 @@
 import { ComponentInstance } from '../component'
 import { currentVMInFn } from '../helper'
 import { hasOwn, warn } from '../utils'
-import { getCurrentVM } from '../runtimeContext'
+import { getCurrentInstance } from '../runtimeContext'
 
 const NOT_FOUND = {}
 export interface InjectionKey<T> extends Symbol {}
@@ -48,7 +48,7 @@ export function inject(
     return defaultValue
   }
 
-  const vm = getCurrentVM()
+  const vm = getCurrentInstance()
   if (vm) {
     const val = resolveInject(key, vm)
     if (val !== NOT_FOUND) {

--- a/src/apis/lifecycle.ts
+++ b/src/apis/lifecycle.ts
@@ -1,6 +1,10 @@
 import { VueConstructor } from 'vue'
 import { ComponentInstance } from '../component'
-import { getCurrentVue, setCurrentVM, getCurrentVM } from '../runtimeContext'
+import {
+  getCurrentVue,
+  setCurrentVM,
+  getCurrentInstance,
+} from '../runtimeContext'
 import { currentVMInFn } from '../helper'
 
 const genName = (name: string) => `on${name[0].toUpperCase() + name.slice(1)}`
@@ -26,7 +30,7 @@ function injectHookOption(
 
 function wrapHookCall(vm: ComponentInstance, fn: Function) {
   return (...args: any) => {
-    let preVm = getCurrentVM()
+    let preVm = getCurrentInstance()
     setCurrentVM(vm)
     try {
       return fn(...args)

--- a/src/apis/watch.ts
+++ b/src/apis/watch.ts
@@ -2,7 +2,7 @@ import { ComponentInstance } from '../component'
 import { Ref, isRef, isReactive } from '../reactivity'
 import { assert, logError, noopFn, warn, isFunction } from '../utils'
 import { defineComponentInstance } from '../helper'
-import { getCurrentVM, getCurrentVue } from '../runtimeContext'
+import { getCurrentInstance, getCurrentVue } from '../runtimeContext'
 import { WatcherPreFlushQueueKey, WatcherPostFlushQueueKey } from '../symbols'
 import { ComputedRef } from './computed'
 
@@ -95,7 +95,7 @@ function getWatchEffectOption(options?: Partial<WatchOptions>): WatchOptions {
 }
 
 function getWatcherVM() {
-  let vm = getCurrentVM()
+  let vm = getCurrentInstance()
   if (!vm) {
     if (!fallbackVM) {
       fallbackVM = defineComponentInstance(getCurrentVue())

--- a/src/createElement.ts
+++ b/src/createElement.ts
@@ -7,7 +7,9 @@ type CreateElement = Vue['$createElement']
 
 let fallbackCreateElement: CreateElement
 
-const createElement: CreateElement = function createElement(...args: any) {
+export const createElement: CreateElement = function createElement(
+  ...args: any
+) {
   if (!currentVM) {
     warn('`createElement()` has been called outside of render function.')
     if (!fallbackCreateElement) {
@@ -20,5 +22,3 @@ const createElement: CreateElement = function createElement(...args: any) {
 
   return currentVM.$createElement.apply(currentVM, args)
 } as any
-
-export default createElement

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,10 +1,10 @@
 import Vue, { VNode, ComponentOptions, VueConstructor } from 'vue'
 import { ComponentInstance } from './component'
-import { currentVue, getCurrentVM } from './runtimeContext'
+import { currentVue, getCurrentInstance } from './runtimeContext'
 import { warn } from './utils'
 
 export function currentVMInFn(hook: string): ComponentInstance | null {
-  const vm = getCurrentVM()
+  const vm = getCurrentInstance()
   if (__DEV__ && !vm) {
     warn(
       `${hook} is called when there is no active component instance to be ` +

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import Vue, { VueConstructor } from 'vue'
-import { Data, SetupFunction, SetupContext } from './component'
+import { Data, SetupFunction } from './component'
 import { currentVue } from './runtimeContext'
 import { install } from './install'
 import { mixin } from './setup'
@@ -21,18 +21,16 @@ if (currentVue && typeof window !== 'undefined' && window.Vue) {
 }
 
 export default plugin
-export { default as createElement } from './createElement'
-export { SetupContext }
+export { createElement as h } from './createElement'
+export { getCurrentInstance } from './runtimeContext'
 export {
   createComponent,
   defineComponent,
   ComponentRenderProxy,
   PropType,
   PropOptions,
+  SetupContext,
 } from './component'
-// For getting a hold of the interal instance in setup() - useful for advanced
-// plugins
-export { getCurrentVM as getCurrentInstance } from './runtimeContext'
 
 export * from './apis/state'
 export * from './apis/lifecycle'

--- a/src/runtimeContext.ts
+++ b/src/runtimeContext.ts
@@ -17,7 +17,7 @@ export function setCurrentVue(vue: VueConstructor) {
   currentVue = vue
 }
 
-export function getCurrentVM(): ComponentInstance | null {
+export function getCurrentInstance(): ComponentInstance | null {
   return currentVM
 }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -6,7 +6,7 @@ import {
   Data,
 } from './component'
 import { Ref, isRef, isReactive, markRaw } from './reactivity'
-import { getCurrentVM, setCurrentVM } from './runtimeContext'
+import { getCurrentInstance, setCurrentVM } from './runtimeContext'
 import { resolveSlots, createSlotProxy } from './helper'
 import { hasOwn, isPlainObject, assert, proxy, warn, isFunction } from './utils'
 import { ref } from './apis/state'
@@ -112,7 +112,7 @@ function activateCurrentInstance(
   fn: (vm_: ComponentInstance) => any,
   onError?: (err: Error) => void
 ) {
-  let preVm = getCurrentVM()
+  let preVm = getCurrentInstance()
   setCurrentVM(vm)
   try {
     return fn(vm)

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -2,7 +2,7 @@ const Vue = require('vue/dist/vue.common.js')
 const {
   ref,
   computed,
-  createElement: h,
+  h,
   provide,
   inject,
   reactive,

--- a/test/setupContext.spec.js
+++ b/test/setupContext.spec.js
@@ -1,5 +1,5 @@
 const Vue = require('vue/dist/vue.common.js')
-const { ref, watch, createElement: h } = require('../src')
+const { h } = require('../src')
 
 describe('setupContext', () => {
   it('should have proper properties', () => {

--- a/test/templateRefs.spec.js
+++ b/test/templateRefs.spec.js
@@ -1,5 +1,5 @@
 const Vue = require('vue/dist/vue.common.js')
-const { ref, watchEffect, watch, createElement: h } = require('../src')
+const { ref, watchEffect } = require('../src')
 
 describe('ref', () => {
   it('should work', (done) => {

--- a/test/types/defineComponent.spec.ts
+++ b/test/types/defineComponent.spec.ts
@@ -1,7 +1,7 @@
 import {
   createComponent,
   defineComponent,
-  createElement as h,
+  h,
   ref,
   SetupContext,
   PropType,

--- a/test/v3/runtime-core/apiLifecycle.spec.ts
+++ b/test/v3/runtime-core/apiLifecycle.spec.ts
@@ -4,7 +4,7 @@ import {
   onBeforeMount,
   onMounted,
   ref,
-  createElement as h,
+  h,
   onBeforeUpdate,
   onUpdated,
   onBeforeUnmount,


### PR DESCRIPTION
Align with vue-next

chore: Renamed `getCurrentVM` to `getCurrentInstance` in the internal code. This should not affect on user side.