### PR TITLE
BREAKING CHANGE: match dist file naming with vue 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./dist/vue-composition-api.common.prod.js')
+} else {
+  module.exports = require('./dist/vue-composition-api.common.js')
+}

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "type": "git",
     "url": "git+https://github.com/vuejs/composition-api.git"
   },
-  "main": "dist/vue-composition-api.js",
-  "umd:main": "dist/vue-composition-api.umd.js",
-  "browser": "dist/vue-composition-api.umd.js",
-  "module": "dist/vue-composition-api.module.js",
+  "main": "index.js",
+  "module": "dist/vue-composition-api.esm.js",
+  "browser": "dist/vue-composition-api.prod.js",
+  "unpkg": "dist/vue-composition-ap.prod.js",
+  "jsdelivr": "dist/vue-composition-api.prod.js",
   "typings": "dist/index.d.ts",
   "author": {
     "name": "liximomo",
@@ -23,7 +24,8 @@
   "license": "MIT",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "index.js"
   ],
   "scripts": {
     "start": "concurrently \"tsc --emitDeclarationOnly -w\" \"cross-env TARGET=es rollup -c -w\"",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,27 +7,27 @@ import dts from 'rollup-plugin-dts'
 
 const builds = {
   'cjs-dev': {
-    outFile: 'vue-composition-api.js',
+    outFile: 'vue-composition-api.common.js',
     format: 'cjs',
     mode: 'development',
   },
   'cjs-prod': {
-    outFile: 'vue-composition-api.min.js',
+    outFile: 'vue-composition-api.common.prod.js',
     format: 'cjs',
     mode: 'production',
   },
   'umd-dev': {
-    outFile: 'vue-composition-api.umd.js',
+    outFile: 'vue-composition-api.js',
     format: 'umd',
     mode: 'development',
   },
   'umd-prod': {
-    outFile: 'vue-composition-api.umd.min.js',
+    outFile: 'vue-composition-api.prod.js',
     format: 'umd',
     mode: 'production',
   },
-  es: {
-    outFile: 'vue-composition-api.module.js',
+  esm: {
+    outFile: 'vue-composition-api.esm.js',
     format: 'es',
     mode: 'development',
   },


### PR DESCRIPTION
match with vue 2 naming style.

Now the dist file would look this:

![image](https://user-images.githubusercontent.com/11247099/85953310-11a3a800-b9a2-11ea-980e-42f580580878.png)

cjs will import dev/prod version based on current env just acting the same behavior as vue. 

This should not affect regular users as the indexes in package.json changed as well.