### PR TITLE
fix: remove "browser" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "main": "index.js",
   "module": "dist/vue-composition-api.esm.js",
-  "browser": "dist/vue-composition-api.prod.js",
   "unpkg": "dist/vue-composition-ap.prod.js",
   "jsdelivr": "dist/vue-composition-api.prod.js",
   "typings": "dist/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -69,9 +69,12 @@ function genConfig({ outFile, format, mode }) {
       }),
       resolve(),
       replace({
-        'process.env.NODE_ENV': JSON.stringify(
-          isProd ? 'production' : 'development'
-        ),
+        'process.env.NODE_ENV':
+          format === 'es'
+            ? // preserve to be handled by bundlers
+              'process.env.NODE_ENV'
+            : // hard coded dev/prod builds
+              JSON.stringify(isProd ? 'production' : 'development'),
         __DEV__:
           format === 'es'
             ? // preserve to be handled by bundlers

--- a/src/apis/inject.ts
+++ b/src/apis/inject.ts
@@ -54,7 +54,7 @@ export function inject(
     if (val !== NOT_FOUND) {
       return val
     } else {
-      if (defaultValue === undefined && process.env.NODE_ENV !== 'production') {
+      if (defaultValue === undefined && __DEV__) {
         warn(`Injection "${String(key)}" not found`, vm)
       }
       return defaultValue


### PR DESCRIPTION
Fix #422 

Webpack has a higher priority to resolve the `browser` field in package.json, which should not be a production build. Removing this will make it uses the "module" field in which the env will be handled by the bundler.q

https://github.com/vuejs/vue/blob/dev/package.json