### PR TITLE
fix: prevent multiple plugins get installed

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -2,7 +2,11 @@ import type { VueConstructor } from 'vue'
 import { AnyObject } from './types/basic'
 import { hasSymbol, hasOwn, isPlainObject, assert } from './utils'
 import { isRef } from './reactivity'
-import { setVueConstructor, isVueRegistered } from './runtimeContext'
+import {
+  setVueConstructor,
+  isVueRegistered,
+  isPluginInstalled,
+} from './runtimeContext'
 import { mixin } from './mixin'
 
 /**
@@ -40,7 +44,7 @@ function mergeData(from: AnyObject, to: AnyObject): Object {
 }
 
 export function install(Vue: VueConstructor) {
-  if (isVueRegistered()) {
+  if (isPluginInstalled() || isVueRegistered(Vue)) {
     if (__DEV__) {
       assert(
         false,
@@ -52,10 +56,7 @@ export function install(Vue: VueConstructor) {
 
   if (__DEV__) {
     if (!Vue.version.startsWith('2.')) {
-      assert(
-        false,
-        `@vue/composition-api only works with Vue 2, v${Vue.version} found.`
-      )
+      assert(false, `only works with Vue 2, v${Vue.version} found.`)
     }
   }
 

--- a/src/runtimeContext.ts
+++ b/src/runtimeContext.ts
@@ -1,12 +1,18 @@
-import { VueConstructor } from 'vue'
+import type { VueConstructor } from 'vue'
 import { ComponentInstance } from './component'
-import { assert } from './utils'
+import { assert, hasOwn } from './utils'
 
 let vueConstructor: VueConstructor | null = null
 let currentInstance: ComponentInstance | null = null
 
-export function isVueRegistered() {
+const PluginInstalledFlag = '__composition_api_installed__'
+
+export function isPluginInstalled() {
   return !!vueConstructor
+}
+
+export function isVueRegistered(Vue: VueConstructor) {
+  return hasOwn(Vue, PluginInstalledFlag)
 }
 
 export function getVueConstructor(): VueConstructor {
@@ -22,6 +28,11 @@ export function getVueConstructor(): VueConstructor {
 
 export function setVueConstructor(Vue: VueConstructor) {
   vueConstructor = Vue
+  Object.defineProperty(Vue, PluginInstalledFlag, {
+    configurable: true,
+    writable: true,
+    value: true,
+  })
 }
 
 export function getCurrentInstance(): ComponentInstance | null {


### PR DESCRIPTION
By injecting and checking the flag on `Vue`, this should prevent multiple composition-api get installed to the same Vue constructor.

Fix #372.