### PR TITLE
fix(type): fix tying issues in #428

### DIFF
--- a/src/component/componentProps.ts
+++ b/src/component/componentProps.ts
@@ -39,27 +39,17 @@ type OptionalKeys<T, MakeDefaultRequired> = Exclude<
   RequiredKeys<T, MakeDefaultRequired>
 >
 
-type ExtractFunctionPropType<
-  T extends Function,
-  TArgs extends Array<any> = any[],
-  TResult = any
-> = T extends (...args: TArgs) => TResult ? T : never
-
-type ExtractCorrectPropType<T> = T extends Function
-  ? ExtractFunctionPropType<T>
-  : Exclude<T, Function>
-
-// prettier-ignore
 type InferPropType<T> = T extends null
   ? any // null & true would fail to infer
   : T extends { type: null | true }
-    ? any // As TS issue https://github.com/Microsoft/TypeScript/issues/14829 // somehow `ObjectConstructor` when inferred from { (): T } becomes `any` // `BooleanConstructor` when inferred from PropConstructor(with PropMethod) becomes `Boolean`
-    : T extends ObjectConstructor | { type: ObjectConstructor }
-      ? { [key: string]: any }
-      : T extends BooleanConstructor | { type: BooleanConstructor }
-        ? boolean
-        : T extends Prop<infer V>
-          ? ExtractCorrectPropType<V> : T;
+  ? any // As TS issue https://github.com/Microsoft/TypeScript/issues/14829 // somehow `ObjectConstructor` when inferred from { (): T } becomes `any` // `BooleanConstructor` when inferred from PropConstructor(with PropMethod) becomes `Boolean`
+  : T extends ObjectConstructor | { type: ObjectConstructor }
+  ? { [key: string]: any }
+  : T extends BooleanConstructor | { type: BooleanConstructor }
+  ? boolean
+  : T extends Prop<infer V>
+  ? V
+  : T
 
 export type ExtractPropTypes<
   O,

--- a/src/component/componentProps.ts
+++ b/src/component/componentProps.ts
@@ -39,17 +39,27 @@ type OptionalKeys<T, MakeDefaultRequired> = Exclude<
   RequiredKeys<T, MakeDefaultRequired>
 >
 
+type ExtractFunctionPropType<
+  T extends Function,
+  TArgs extends Array<any> = any[],
+  TResult = any
+> = T extends (...args: TArgs) => TResult ? T : any
+
+type ExtractCorrectPropType<T> = T extends Function
+  ? ExtractFunctionPropType<T>
+  : Exclude<T, Function>
+
+// prettier-ignore
 type InferPropType<T> = T extends null
   ? any // null & true would fail to infer
   : T extends { type: null | true }
-  ? any // As TS issue https://github.com/Microsoft/TypeScript/issues/14829 // somehow `ObjectConstructor` when inferred from { (): T } becomes `any` // `BooleanConstructor` when inferred from PropConstructor(with PropMethod) becomes `Boolean`
-  : T extends ObjectConstructor | { type: ObjectConstructor }
-  ? { [key: string]: any }
-  : T extends BooleanConstructor | { type: BooleanConstructor }
-  ? boolean
-  : T extends Prop<infer V>
-  ? V
-  : T
+    ? any // As TS issue https://github.com/Microsoft/TypeScript/issues/14829 // somehow `ObjectConstructor` when inferred from { (): T } becomes `any` // `BooleanConstructor` when inferred from PropConstructor(with PropMethod) becomes `Boolean`
+    : T extends ObjectConstructor | { type: ObjectConstructor }
+      ? { [key: string]: any }
+      : T extends BooleanConstructor | { type: BooleanConstructor }
+        ? boolean
+        : T extends Prop<infer V>
+          ? ExtractCorrectPropType<V> : T;
 
 export type ExtractPropTypes<
   O,

--- a/src/component/componentProxy.ts
+++ b/src/component/componentProxy.ts
@@ -27,17 +27,12 @@ export type ComponentRenderProxy<
   $data: D
   $props: Readonly<P & PublicProps>
   $attrs: Data
-  $refs: Data
-  $slots: Data
-  $root: ComponentInstance | null
-  $parent: ComponentInstance | null
-  $emit: (event: string, ...args: unknown[]) => void
 } & Readonly<P> &
   UnwrapRef<B> &
   D &
   M &
   ExtractComputedReturns<C> &
-  Vue
+  Omit<Vue, '$data' | '$props' | '$attrs'>
 
 // for Vetur and TSX support
 type VueConstructorProxy<PropsOptions, RawBindings> = VueConstructor & {


### PR DESCRIPTION
- Omit some Vue attributes to override with our custom ones
- Fix `ExtractFunctionPropType` to accept general functions