### PR TITLE
fix PropType

### DIFF
--- a/src/component/componentProps.ts
+++ b/src/component/componentProps.ts
@@ -43,7 +43,7 @@ type ExtractFunctionPropType<
   T extends Function,
   TArgs extends Array<any> = any[],
   TResult = any
-> = T extends (...args: TArgs) => TResult ? T : any
+> = T extends (...args: TArgs) => TResult ? T : never
 
 type ExtractCorrectPropType<T> = T extends Function
   ? ExtractFunctionPropType<T>

--- a/src/component/componentProps.ts
+++ b/src/component/componentProps.ts
@@ -58,8 +58,10 @@ type InferPropType<T> = T extends null
       ? { [key: string]: any }
       : T extends BooleanConstructor | { type: BooleanConstructor }
         ? boolean
-        : T extends Prop<infer V>
-          ? ExtractCorrectPropType<V> : T;
+        : T extends FunctionConstructor
+          ? Function
+          : T extends Prop<infer V>
+            ? ExtractCorrectPropType<V> : T;
 
 export type ExtractPropTypes<
   O,

--- a/test-dts/defineComponent.test-d.ts
+++ b/test-dts/defineComponent.test-d.ts
@@ -3,7 +3,7 @@ import {
   reactive,
   expectType,
   expectError,
-  isNotAny,
+  isNotAnyOrUndefined,
   defineComponent,
   PropType,
 } from './index'
@@ -89,19 +89,19 @@ describe('with object props', () => {
       expectType<ExpectedProps['fff']>(props.fff)
       expectType<ExpectedProps['hhh']>(props.hhh)
 
-      isNotAny(props.a)
-      isNotAny(props.b)
-      isNotAny(props.e)
-      isNotAny(props.bb)
-      isNotAny(props.cc)
-      isNotAny(props.dd)
-      isNotAny(props.ee)
-      isNotAny(props.ff)
-      isNotAny(props.ccc)
-      isNotAny(props.ddd)
-      isNotAny(props.eee)
-      isNotAny(props.fff)
-      isNotAny(props.hhh)
+      isNotAnyOrUndefined(props.a)
+      isNotAnyOrUndefined(props.b)
+      isNotAnyOrUndefined(props.e)
+      isNotAnyOrUndefined(props.bb)
+      isNotAnyOrUndefined(props.cc)
+      isNotAnyOrUndefined(props.dd)
+      isNotAnyOrUndefined(props.ee)
+      isNotAnyOrUndefined(props.ff)
+      isNotAnyOrUndefined(props.ccc)
+      isNotAnyOrUndefined(props.ddd)
+      isNotAnyOrUndefined(props.eee)
+      isNotAnyOrUndefined(props.fff)
+      isNotAnyOrUndefined(props.hhh)
 
       expectError((props.a = 1))
 

--- a/test-dts/defineComponent.test-d.ts
+++ b/test-dts/defineComponent.test-d.ts
@@ -3,6 +3,7 @@ import {
   reactive,
   expectType,
   expectError,
+  isNotAny,
   defineComponent,
   PropType,
 } from './index'
@@ -87,6 +88,20 @@ describe('with object props', () => {
       expectType<ExpectedProps['eee']>(props.eee)
       expectType<ExpectedProps['fff']>(props.fff)
       expectType<ExpectedProps['hhh']>(props.hhh)
+
+      isNotAny(props.a)
+      isNotAny(props.b)
+      isNotAny(props.e)
+      isNotAny(props.bb)
+      isNotAny(props.cc)
+      isNotAny(props.dd)
+      isNotAny(props.ee)
+      isNotAny(props.ff)
+      isNotAny(props.ccc)
+      isNotAny(props.ddd)
+      isNotAny(props.eee)
+      isNotAny(props.fff)
+      isNotAny(props.hhh)
 
       expectError((props.a = 1))
 

--- a/test-dts/index.d.ts
+++ b/test-dts/index.d.ts
@@ -5,3 +5,7 @@ export function describe(_name: string, _fn: () => void): void
 export function expectType<T>(value: T): void
 export function expectError<T>(value: T): void
 export function expectAssignable<T, T2 extends T = T>(value: T2): void
+
+// https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
+type IfNotAny<T> = 0 extends 1 & T ? never : T
+export function isNotAny<T>(value: IfNotAny<T>): void

--- a/test-dts/index.d.ts
+++ b/test-dts/index.d.ts
@@ -8,4 +8,5 @@ export function expectAssignable<T, T2 extends T = T>(value: T2): void
 
 // https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
 type IfNotAny<T> = 0 extends 1 & T ? never : T
-export function isNotAny<T>(value: IfNotAny<T>): void
+type IfNotUndefined<T> = Exclude<T, undefined> extends never ? never : T
+export function isNotAnyOrUndefined<T>(value: IfNotAny<IfNotUndefined<T>>): void


### PR DESCRIPTION
Fixed prop types becoming `any` or `undefined`.

- Reverted #444 because it changed some types of prop to `any` type
- Added tests to check whether it is not `any` type
- Fixed `Function` not to be `undefined` now it becomes `Function`
- Added tests to check whether it is not `undefined` type (of course it allows optional types)
