### PR TITLE
types: improve typings for `shallowRef`

### DIFF
--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -167,7 +167,10 @@ export function toRef<T extends object, K extends keyof T>(
   })
 }
 
-export function shallowRef<T>(value: T): T extends Ref ? T : Ref<T>
+export function shallowRef<T extends object>(
+  value: T
+): T extends Ref ? T : Ref<T>
+export function shallowRef<T>(value: T): Ref<T>
 export function shallowRef<T = any>(): Ref<T | undefined>
 export function shallowRef(raw?: unknown) {
   if (isRef(raw)) {

--- a/test-dts/ref.test-d.ts
+++ b/test-dts/ref.test-d.ts
@@ -1,4 +1,12 @@
-import { Ref, ref, isRef, unref, reactive, expectType } from './index'
+import {
+  Ref,
+  ref,
+  shallowRef,
+  isRef,
+  unref,
+  reactive,
+  expectType,
+} from './index'
 
 function plainType(arg: number | Ref<number>) {
   // ref coercing
@@ -92,3 +100,18 @@ const state = reactive({
 })
 
 expectType<string>(state.foo.label)
+
+type Status = 'initial' | 'ready' | 'invalidating'
+const shallowStatus = shallowRef<Status>('initial')
+if (shallowStatus.value === 'initial') {
+  expectType<Ref<Status>>(shallowStatus)
+  expectType<Status>(shallowStatus.value)
+  shallowStatus.value = 'invalidating'
+}
+
+const refStatus = ref<Status>('initial')
+if (refStatus.value === 'initial') {
+  expectType<Ref<Status>>(shallowStatus)
+  expectType<Status>(shallowStatus.value)
+  refStatus.value = 'invalidating'
+}


### PR DESCRIPTION
fix https://github.com/vuejs/composition-api/issues/453

```ts
const STATUS_INITIAL = 'initial'
const STATUS_READY = 'ready'
const STATUS_INVALIDATING = 'invalidating'

type Status = 'initial' | 'ready' | 'invalidating'

const status = shallowRef<Status>(STATUS_INITIAL)

if (status.value === STATUS_READY) {
    status.value = STATUS_INVALIDATING
}
```

Explanation `shallowRef<Status>` is returning `Ref<'initial'> |  Ref<'ready'> | Ref<'invalidating'>` so when you do 
```ts

if (status.value === STATUS_READY) {
  // status === Ref<'ready'> 
}
```


Same as https://github.com/vuejs/vue-next/pull/1780
