### PR TITLE
docs: added minzipped size badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Vue 2 plugin for **Composition API**
 
 [![npm](https://img.shields.io/npm/v/@vue/composition-api)](https://www.npmjs.com/package/@vue/composition-api)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/vuejs/composition-api/Build%20&%20Test)](https://github.com/vuejs/composition-api/actions?query=workflow%3A%22Build+%26+Test%22)
+[![Minzipped size](https://badgen.net/bundlephobia/minzip/@vue/composition-api)](https://bundlephobia.com/result?p=@vue/composition-api)
+
+
 
 English | [中文](./README.zh-CN.md) ・ [**Composition API Docs**](https://composition-api.vuejs.org/)
 


### PR DESCRIPTION
Bundle size is often one of the first questions asked when deciding to add a dependency.

Added a bundle-size badge to advertise the small size.