### PR TITLE
fix(watch): using deep:true in SSR context

### DIFF
--- a/src/apis/watch.ts
+++ b/src/apis/watch.ts
@@ -321,7 +321,7 @@ function createWatcher(
 
   // if the return value is reactive and deep:true
   // watch for changes, this might happen when new key is added
-  if (isReactive(watcher.value) && deep) {
+  if (isReactive(watcher.value) && watcher.value.__ob__?.dep && deep) {
     watcher.value.__ob__.dep.addSub({
       update() {
         // this will force the source to be revaluated and the callback


### PR DESCRIPTION
fix #473 


I don't know what is causing this to happen, so I can't test this.

This should never happen because the `watcher.value` is still reactive but doesn't have `__ob__`