### PR TITLE
chore: expose package version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Github Release
+
+on: 
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - name: Create Release
+        run: npx conventional-github-releaser -p angular
+        env:
+          CI: true
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "update-readme": "node ./scripts/update-readme.js",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "version": "yarn changelog && yarn update-readme && git add CHANGELOG.md README.*",
-    "release": "yarn test && yarn publish && git push && yarn release-gh",
+    "release": "yarn version && yarn test && yarn publish --non-interactive && git push --follow-tags",
     "release-gh": "conventional-github-releaser -p angular"
   },
   "bugs": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import resolve from '@rollup/plugin-node-resolve'
 import { terser } from 'rollup-plugin-terser'
 import replace from '@rollup/plugin-replace'
 import dts from 'rollup-plugin-dts'
+import { version } from './package.json'
 
 const builds = {
   'cjs-dev': {
@@ -81,6 +82,7 @@ function genConfig({ outFile, format, mode }) {
               `(process.env.NODE_ENV !== 'production')`
             : // hard coded dev/prod builds
               !isProd,
+        __VERSION__: JSON.stringify(version),
       }),
       isProd && terser(),
     ].filter(Boolean),

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,2 +1,3 @@
 // Global compile-time constants
-declare var __DEV__: boolean
+declare const __DEV__: boolean
+declare const __VERSION__: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import type Vue from 'vue'
 import { Data, SetupFunction } from './component'
 import { Plugin } from './install'
 
+export const version = __VERSION__
+
 export * from './apis'
 export { getCurrentInstance } from './runtimeContext'
 export {


### PR DESCRIPTION
closes #478 

- Expose package version
- Changed the timing for publishing (bump version first and then build)
- Add a Github action to create Github release notes on tag pushes