### PR TITLE
fix(sets): check for window to avoid SSR errors

### DIFF
--- a/src/utils/sets.ts
+++ b/src/utils/sets.ts
@@ -1,4 +1,4 @@
-if (!('WeakSet' in window)) {
+if (typeof window !== 'undefined' && !('WeakSet' in window)) {
   // simple polyfil for IE
   Object.defineProperty(window, 'WeakSet', {
     value: new (class {


### PR DESCRIPTION
Hey 👋🏻

The new version unfortunately breaks when using the composition API on server-side because of a missing check for `typeof window !== 'undefined'`.

<img width="838" alt="image" src="https://user-images.githubusercontent.com/640208/92989782-0a873300-f4d7-11ea-8f42-83012e8350dd.png">

This PR should add the check and avoid SSR errors 😋