### PR TITLE
feat: making all vue2 reactive object be valid isReactive

### DIFF
--- a/src/apis/state.ts
+++ b/src/apis/state.ts
@@ -2,7 +2,6 @@ export {
   isReactive,
   isRef,
   markRaw,
-  markReactive,
   reactive,
   ref,
   customRef,

--- a/src/install.ts
+++ b/src/install.ts
@@ -72,14 +72,6 @@ export function install(Vue: VueConstructor) {
     }
   }
 
-  // const observable = Vue.observable
-
-  // Vue.observable = (obj: any) => {
-  //   const o = observable(obj)
-  //   // markReactive(o)
-  //   return o
-  // }
-
   setVueConstructor(Vue)
   mixin(Vue)
 }

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,7 +1,7 @@
 import type { VueConstructor } from 'vue'
 import { AnyObject } from './types/basic'
 import { hasSymbol, hasOwn, isPlainObject, assert, warn } from './utils'
-import { isRef, markReactive } from './reactivity'
+import { isRef } from './reactivity'
 import { setVueConstructor, isVueRegistered } from './runtimeContext'
 import { mixin } from './mixin'
 
@@ -72,13 +72,13 @@ export function install(Vue: VueConstructor) {
     }
   }
 
-  const observable = Vue.observable
+  // const observable = Vue.observable
 
-  Vue.observable = (obj: any) => {
-    const o = observable(obj)
-    markReactive(o)
-    return o
-  }
+  // Vue.observable = (obj: any) => {
+  //   const o = observable(obj)
+  //   // markReactive(o)
+  //   return o
+  // }
 
   setVueConstructor(Vue)
   mixin(Vue)

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -5,7 +5,7 @@ import {
   SetupFunction,
   Data,
 } from './component'
-import { isRef, isReactive, markRaw, markReactive, toRefs } from './reactivity'
+import { isRef, isReactive, markRaw, toRefs } from './reactivity'
 import { isPlainObject, assert, proxy, warn, isFunction } from './utils'
 import { ref } from './apis'
 import vmStateManager from './utils/vmStateManager'
@@ -74,7 +74,8 @@ export function mixin(Vue: VueConstructor) {
     const ctx = createSetupContext(vm)
 
     // mark props
-    markReactive(props)
+    // markReactive(props)
+    props.__ob__ = true // fake reactive
 
     // resolve scopedSlots and slots to functions
     resolveScopedSlots(vm, ctx.slots)

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -23,6 +23,7 @@ import {
   resolveScopedSlots,
   asVmProperty,
 } from './utils/instance'
+import { PropsReactive } from './utils/symbols'
 
 export function mixin(Vue: VueConstructor) {
   Vue.mixin({
@@ -82,7 +83,7 @@ export function mixin(Vue: VueConstructor) {
     const ctx = createSetupContext(vm)
 
     // fake reactive for `toRefs(props)`
-    def(props, '__props_reactive__', true)
+    def(props, PropsReactive, true)
 
     // resolve scopedSlots and slots to functions
     resolveScopedSlots(vm, ctx.slots)

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -81,7 +81,7 @@ export function mixin(Vue: VueConstructor) {
     const ctx = createSetupContext(vm)
 
     // fake reactive for `toRefs(props)`
-    props.__ob__ = true
+    props.__props_reactive__ = true
 
     // resolve scopedSlots and slots to functions
     resolveScopedSlots(vm, ctx.slots)

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -80,15 +80,15 @@ export function mixin(Vue: VueConstructor) {
     const setup = vm.$options.setup!
     const ctx = createSetupContext(vm)
 
-    // mark props
-    // markReactive(props)
-    props.__ob__ = true // fake reactive
+    // fake reactive for `toRefs(props)`
+    props.__ob__ = true
 
     // resolve scopedSlots and slots to functions
     resolveScopedSlots(vm, ctx.slots)
 
     let binding: ReturnType<SetupFunction<Data, Data>> | undefined | null
     activateCurrentInstance(vm, () => {
+      // make props to be fake reactive, this is for `toRefs(props)`
       binding = setup(props, ctx)
     })
 

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -13,6 +13,7 @@ import {
   warn,
   isFunction,
   isObject,
+  def,
 } from './utils'
 import { ref } from './apis'
 import vmStateManager from './utils/vmStateManager'
@@ -81,7 +82,7 @@ export function mixin(Vue: VueConstructor) {
     const ctx = createSetupContext(vm)
 
     // fake reactive for `toRefs(props)`
-    props.__props_reactive__ = true
+    def(props, '__props_reactive__', true)
 
     // resolve scopedSlots and slots to functions
     resolveScopedSlots(vm, ctx.slots)

--- a/src/reactivity/index.ts
+++ b/src/reactivity/index.ts
@@ -5,7 +5,6 @@ export {
   shallowReactive,
   toRaw,
   isRaw,
-  markReactive,
   isReadonly,
   shallowReadonly,
 } from './reactive'

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -4,7 +4,7 @@ import { isPlainObject, def, warn } from '../utils'
 import { isComponentInstance, defineComponentInstance } from '../utils/helper'
 import { RefKey } from '../utils/symbols'
 import { isRef, UnwrapRef } from './ref'
-import { rawSet, reactiveSet, readonlySet } from '../utils/sets'
+import { rawSet, accessModifiedSet, readonlySet } from '../utils/sets'
 
 export function isRaw(obj: any): boolean {
   return obj && typeof obj === 'object' && '__ob__' in obj && obj.__ob__.__raw__
@@ -35,11 +35,11 @@ function setupAccessControl(target: AnyObject): void {
     Array.isArray(target) ||
     isRef(target) ||
     isComponentInstance(target) ||
-    reactiveSet.has(target)
+    accessModifiedSet.has(target)
   )
     return
 
-  reactiveSet.add(target)
+  accessModifiedSet.add(target)
 
   const keys = Object.keys(target)
   for (let i = 0; i < keys.length; i++) {

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -271,5 +271,7 @@ export function toRaw<T>(observed: T): T {
     return observed
   }
 
-  return (observed as any).__ob__.value || observed
+  return (
+    ((observed as any).__ob__ && (observed as any).__ob__.value) || observed
+  )
 }

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -39,6 +39,8 @@ function setupAccessControl(target: AnyObject): void {
   )
     return
 
+  reactiveSet.add(target)
+
   const keys = Object.keys(target)
   for (let i = 0; i < keys.length; i++) {
     defineAccessControl(target, keys[i])

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -135,6 +135,7 @@ export function shallowReactive<T extends object = any>(obj: T): T {
   const ob = (observed as any).__ob__
 
   for (const key of Object.keys(obj)) {
+    // @ts-ignore
     let val = obj[key]
     let getter: (() => any) | undefined
     let setter: ((x: any) => void) | undefined
@@ -149,6 +150,7 @@ export function shallowReactive<T extends object = any>(obj: T): T {
         (!getter || setter) /* not only have getter */ &&
         arguments.length === 2
       ) {
+        // @ts-ignore
         val = obj[key]
       }
     }
@@ -208,6 +210,7 @@ export function shallowReadonly<T extends object>(obj: T): Readonly<T> {
   const ob = (source as any).__ob__
 
   for (const key of Object.keys(obj)) {
+    // @ts-ignore
     let val = obj[key]
     let getter: (() => any) | undefined
     let setter: ((x: any) => void) | undefined
@@ -222,6 +225,7 @@ export function shallowReadonly<T extends object>(obj: T): Readonly<T> {
         (!getter || setter) /* not only have getter */ &&
         arguments.length === 2
       ) {
+        // @ts-ignore
         val = obj[key]
       }
     }

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -39,7 +39,7 @@ function setupAccessControl(target: AnyObject): void {
   )
     return
 
-  accessModifiedSet.add(target)
+  accessModifiedSet.set(target, true)
 
   const keys = Object.keys(target)
   for (let i = 0; i < keys.length; i++) {
@@ -248,7 +248,7 @@ export function shallowReadonly<T extends object>(obj: T): Readonly<T> {
     })
   }
 
-  readonlySet.add(readonlyObj)
+  readonlySet.set(readonlyObj, true)
 
   return readonlyObj as any
 }
@@ -267,7 +267,7 @@ export function markRaw<T extends object>(obj: T): T {
   def(obj, '__ob__', ob)
 
   // mark as Raw
-  rawSet.add(obj)
+  rawSet.set(obj, true)
 
   return obj
 }

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -114,13 +114,16 @@ export function ref(raw?: unknown) {
 export function isRef<T>(value: any): value is Ref<T> {
   return value instanceof RefImpl
 }
+function isPropObject(obj: unknown) {
+  return obj && typeof obj === 'object' && '__props_reactive__' in obj
+}
 
 export function unref<T>(ref: T): T extends Ref<infer V> ? V : T {
   return isRef(ref) ? (ref.value as any) : ref
 }
 
 export function toRefs<T extends Data = Data>(obj: T): ToRefs<T> {
-  if (__DEV__ && !isReactive(obj)) {
+  if (__DEV__ && !isReactive(obj) && !isPropObject(obj)) {
     warn(`toRefs() expects a reactive object but received a plain one.`)
   }
   if (!isPlainObject(obj)) return obj as any

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -90,7 +90,7 @@ export function createRef<T>(options: RefOption<T>, readonly = false) {
   // related issues: #79
   const sealed = Object.seal(r)
 
-  readonlySet.add(sealed)
+  readonlySet.set(sealed, true)
   return sealed
 }
 

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -1,5 +1,5 @@
 import { Data } from '../component'
-import { RefKey } from '../utils/symbols'
+import { RefKey, PropsReactive } from '../utils/symbols'
 import { proxy, isPlainObject, warn } from '../utils'
 import { reactive, isReactive, shallowReactive } from './reactive'
 import { readonlySet } from '../utils/sets'
@@ -115,7 +115,7 @@ export function isRef<T>(value: any): value is Ref<T> {
   return value instanceof RefImpl
 }
 function isPropObject(obj: unknown) {
-  return obj && typeof obj === 'object' && '__props_reactive__' in obj
+  return obj && typeof obj === 'object' && PropsReactive in obj
 }
 
 export function unref<T>(ref: T): T extends Ref<infer V> ? V : T {

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -120,11 +120,10 @@ export function unref<T>(ref: T): T extends Ref<infer V> ? V : T {
 }
 
 export function toRefs<T extends Data = Data>(obj: T): ToRefs<T> {
-  if (!isPlainObject(obj)) return obj as any
-
   if (__DEV__ && !isReactive(obj)) {
     warn(`toRefs() expects a reactive object but received a plain one.`)
   }
+  if (!isPlainObject(obj)) return obj as any
 
   const ret: any = {}
   for (const key in obj) {

--- a/src/reactivity/set.ts
+++ b/src/reactivity/set.ts
@@ -1,6 +1,6 @@
 import { getVueConstructor } from '../runtimeContext'
 import { isArray } from '../utils'
-import { defineAccessControl, markReactive } from './reactive'
+import { defineAccessControl } from './reactive'
 
 function isUndef(v: any): boolean {
   return v === undefined || v === null
@@ -59,7 +59,6 @@ export function set<T>(target: any, key: any, val: T): T {
   defineReactive(ob.value, key, val)
   // IMPORTANT: define access control before trigger watcher
   defineAccessControl(target, key, val)
-  markReactive(ob.value[key])
 
   ob.dep.notify()
   return val

--- a/src/utils/instance.ts
+++ b/src/utils/instance.ts
@@ -12,23 +12,32 @@ export function asVmProperty(
 ) {
   const props = vm.$options.props
   if (!(propName in vm) && !(props && hasOwn(props, propName))) {
-    proxy(vm, propName, {
-      get: () => propValue.value,
-      set: (val: unknown) => {
-        propValue.value = val
-      },
-    })
+    if (isRef(propValue)) {
+      proxy(vm, propName, {
+        get: () => propValue.value,
+        set: (val: unknown) => {
+          propValue.value = val
+        },
+      })
+    } else {
+      // @ts-ignore
+      vm[propName] = propValue
+    }
 
     if (__DEV__) {
       // expose binding to Vue Devtool as a data property
       // delay this until state has been resolved to prevent repeated works
       vm.$nextTick(() => {
-        proxy(vm._data, propName, {
-          get: () => propValue.value,
-          set: (val: unknown) => {
-            propValue.value = val
-          },
-        })
+        if (isRef(propValue)) {
+          proxy(vm._data, propName, {
+            get: () => propValue.value,
+            set: (val: unknown) => {
+              propValue.value = val
+            },
+          })
+        } else {
+          vm._data[propName] = propValue
+        }
       })
     }
   } else if (__DEV__) {

--- a/src/utils/sets.ts
+++ b/src/utils/sets.ts
@@ -16,6 +16,6 @@ if (typeof window !== 'undefined' && !('WeakSet' in window)) {
   })
 }
 
-export const reactiveSet = new WeakSet()
+export const accessModifiedSet = new WeakSet()
 export const rawSet = new WeakSet()
 export const readonlySet = new WeakSet()

--- a/src/utils/sets.ts
+++ b/src/utils/sets.ts
@@ -1,21 +1,3 @@
-if (typeof window !== 'undefined' && !('WeakSet' in window)) {
-  // simple polyfil for IE
-  Object.defineProperty(window, 'WeakSet', {
-    value: new (class {
-      constructor(private _map = new WeakMap()) {}
-      has(v: object): boolean {
-        return this._map.has(v)
-      }
-      add(v: object) {
-        return this._map.set(v, true)
-      }
-      remove(v: object) {
-        return this._map.set(v, true)
-      }
-    })(),
-  })
-}
-
-export const accessModifiedSet = new WeakSet()
-export const rawSet = new WeakSet()
-export const readonlySet = new WeakSet()
+export const accessModifiedSet = new WeakMap()
+export const rawSet = new WeakMap()
+export const readonlySet = new WeakMap()

--- a/src/utils/symbols.ts
+++ b/src/utils/symbols.ts
@@ -13,3 +13,4 @@ export const WatcherPostFlushQueueKey = createSymbol(
 
 // must be a string, symbol key is ignored in reactive
 export const RefKey = 'composition-api.refKey'
+export const PropsReactive = '__props_reactive__'

--- a/test/apis/state.spec.js
+++ b/test/apis/state.spec.js
@@ -392,4 +392,14 @@ describe('unwrapping', () => {
     expect(state.double).toBe(2)
     expect(spy).toHaveBeenCalled()
   })
+
+  // #517
+  it('should not throw callstack error', () => {
+    const a = {
+      b: 1,
+    }
+    a.a = a
+
+    reactive(a)
+  })
 })

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -180,54 +180,54 @@ describe('setup', () => {
   })
 
   // `props` are not deeply reactive
-  // it('not warn doing toRef on props', async () => {
-  //   const Foo = {
-  //     props: {
-  //       obj: {
-  //         type: Object,
-  //         required: true,
-  //       },
-  //     },
-  //     setup(props) {
-  //       return () =>
-  //         h('div', null, [
-  //           h('span', toRefs(props.obj).bar.value),
-  //           h('span', toRefs(props.obj.nested).baz.value),
-  //         ])
-  //     },
-  //   }
+  it('not warn doing toRef on props', async () => {
+    const Foo = {
+      props: {
+        obj: {
+          type: Object,
+          required: true,
+        },
+      },
+      setup(props) {
+        return () =>
+          h('div', null, [
+            h('span', toRefs(props.obj).bar.value),
+            h('span', toRefs(props.obj.nested).baz.value),
+          ])
+      },
+    }
 
-  //   let bar
-  //   let baz
+    let bar
+    let baz
 
-  //   const vm = new Vue({
-  //     template: `<div id="app"><Foo :obj="obj" /></div>`,
-  //     components: { Foo },
-  //     setup() {
-  //       bar = ref(3)
-  //       baz = ref(1)
-  //       return {
-  //         obj: {
-  //           bar,
-  //           nested: {
-  //             baz,
-  //           },
-  //         },
-  //       }
-  //     },
-  //   })
-  //   vm.$mount()
+    const vm = new Vue({
+      template: `<div id="app"><Foo :obj="obj" /></div>`,
+      components: { Foo },
+      setup() {
+        bar = ref(3)
+        baz = ref(1)
+        return {
+          obj: {
+            bar,
+            nested: {
+              baz,
+            },
+          },
+        }
+      },
+    })
+    vm.$mount()
 
-  //   expect(warn).not.toHaveBeenCalled()
-  //   expect(vm.$el.textContent).toBe('31')
+    expect(vm.$el.textContent).toBe('31')
 
-  //   bar.value = 4
-  //   baz.value = 2
+    bar.value = 4
+    baz.value = 2
 
-  //   await vm.$nextTick()
-  //   expect(warn).not.toHaveBeenCalled()
-  //   expect(vm.$el.textContent).toBe('42')
-  // })
+    await vm.$nextTick()
+    expect(vm.$el.textContent).toBe('42')
+
+    expect(warn).toHaveBeenCalledTimes(4) // 2 renders - 2 calls each render
+  })
 
   it('should merge result properly', () => {
     const injectKey = Symbol('foo')
@@ -414,11 +414,11 @@ describe('setup', () => {
     waitForUpdate(() => {
       expect(vm.$el.textContent).toBe('1, 2')
 
-      // should trigger a re-render
+      // not trigger event
       vm.form = { a: 2, b: 3 }
     })
       .then(() => {
-        expect(vm.$el.textContent).toBe('2, 3')
+        expect(vm.$el.textContent).toBe('1, 2')
       })
       .then(done)
   })


### PR DESCRIPTION
fix #517 

Simplifying the logic of `isReactive` now every valid reactive v2 object will be a valid isReactive object.

The only issue with this is `isReactive(obj) === true` won't mean auto-unwrapping 


```ts
const obj = Vue.observable({ a: ref(1) })
const reactiveObj = reactive({a: ref(1) })

isReactive(obj) // true

isReactive(reactiveObj) // true


obj.a // {value:1}
reactiveObj.a // 1

```

