### PR TITLE
feat(reactive): allow usage of reactive before `Vue.use`

### DIFF
--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -1,5 +1,5 @@
 import { AnyObject } from '../types/basic'
-import { getVueConstructor } from '../runtimeContext'
+import { getRegisteredVueOrDefault } from '../runtimeContext'
 import { isPlainObject, def, warn } from '../utils'
 import { isComponentInstance, defineComponentInstance } from '../utils/helper'
 import { RefKey } from '../utils/symbols'
@@ -94,7 +94,7 @@ export function defineAccessControl(target: AnyObject, key: any, val?: any) {
 }
 
 function observe<T>(obj: T): T {
-  const Vue = getVueConstructor()
+  const Vue = getRegisteredVueOrDefault()
   let observed: T
   if (Vue.observable) {
     observed = Vue.observable(obj)

--- a/src/runtimeContext.ts
+++ b/src/runtimeContext.ts
@@ -2,6 +2,14 @@ import type { VueConstructor } from 'vue'
 import { ComponentInstance } from './component'
 import { assert, hasOwn, warn } from './utils'
 
+let vueDependency: VueConstructor | undefined = undefined
+
+try {
+  vueDependency = require('vue')
+} catch {
+  // not available
+}
+
 let vueConstructor: VueConstructor | null = null
 let currentInstance: ComponentInstance | null = null
 
@@ -24,6 +32,17 @@ export function getVueConstructor(): VueConstructor {
   }
 
   return vueConstructor!
+}
+
+// returns registered vue or `vue` dependency
+export function getRegisteredVueOrDefault(): VueConstructor {
+  let constructor = vueConstructor || vueDependency
+
+  if (__DEV__) {
+    assert(vueConstructor, `No vue dependency found.`)
+  }
+
+  return constructor!
 }
 
 export function setVueConstructor(Vue: VueConstructor) {


### PR DESCRIPTION
Allowing define `reactive` and `ref` before the `Vue.use`, the only caveat is when you have different `vue` versions installed. 

I think this is a pretty edge case and most of the time the user will use the version from `required('vue')`


> Note: would be nice to validate if reactive was used and if it was before the `Vue.use` and the `Vue.use` resolves to a different Vue constructor we could warn it


```js
// something like this
export function setVueConstructor(Vue: VueConstructor) {
  if (__DEV__ && vueConstructor) {
    warn('Another instance of vue installed')
  }

  if(__DEV__ && !vueConstructor && hasReactiveBeenUsed && vueConstructor !== vueDependency) {
    warn('reactive was used globally with a different Vue instance, this might cause reactivity to fail')
  }
  vueConstructor = Vue
  Object.defineProperty(Vue, PluginInstalledFlag, {
    configurable: true,
    writable: true,
    value: true,
  })
}
```