### PR TITLE
fix: reactive array

### DIFF
--- a/src/apis/computed.ts
+++ b/src/apis/computed.ts
@@ -6,6 +6,7 @@ import {
   defineComponentInstance,
   getVueInternalClasses,
 } from '../utils'
+import { isFunction } from 'util'
 
 interface Option<T> {
   get: () => T

--- a/test/apis/computed.spec.js
+++ b/test/apis/computed.spec.js
@@ -1,5 +1,5 @@
 const Vue = require('vue/dist/vue.common.js')
-const { ref, computed, isReadonly } = require('../../src')
+const { ref, computed, isReadonly, reactive } = require('../../src')
 
 describe('Hooks computed', () => {
   beforeEach(() => {
@@ -211,5 +211,25 @@ describe('Hooks computed', () => {
     })
     expect(isReadonly(z.value)).toBe(false)
     expect(isReadonly(z.value.a)).toBe(false)
+  })
+
+  it('should support array', () => {
+    const a = reactive([1])
+
+    const d = a.__ob__.dep.depend
+
+    a.__ob__.dep.depend = () => {
+      debugger
+      return d(...arguments)
+    }
+
+    const len = computed(() => {
+      return a.length
+    })
+
+    expect(len.value).toBe(1)
+
+    a.push(1)
+    expect(len.value).toBe(2)
   })
 })

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -10,6 +10,7 @@ const {
   markRaw,
   toRaw,
   nextTick,
+  shallowReactive,
 } = require('../src')
 const { sleep } = require('./helpers/utils')
 
@@ -885,5 +886,28 @@ describe('setup', () => {
     await sleep(10)
     await nextTick()
     expect(vm.$el.textContent).toBe('2')
+  })
+
+  // #521
+  it('should handle array updates', (done) => {
+    const a = reactive([])
+    const opts = {
+      template: '<div>{{ a }}</div>',
+      setup() {
+        return {
+          a,
+        }
+      },
+    }
+    const Constructor = Vue.extend(opts).extend({})
+
+    const vm = new Vue(Constructor).$mount()
+
+    expect(vm.$el.textContent).toBe('[]')
+
+    a.push(1)
+    waitForUpdate(() => {
+      expect(vm.$el.textContent).toBe('[ 1 ]')
+    }).then(done)
   })
 })

--- a/test/v3/reactivity/reactiveArray.spec.ts
+++ b/test/v3/reactivity/reactiveArray.spec.ts
@@ -1,0 +1,176 @@
+import {
+  ref,
+  isRef,
+  reactive,
+  isReactive,
+  toRaw,
+  watchEffect,
+} from '../../../src'
+
+describe('reactivity/reactive/Array', () => {
+  test('should make Array reactive', () => {
+    const original = [{ foo: 1 }]
+    const observed = reactive(original)
+    expect(observed).not.toBe(original)
+    expect(isReactive(observed)).toBe(true)
+    expect(isReactive(original)).toBe(false)
+    expect(isReactive(observed[0])).toBe(true)
+    // get
+    expect(observed[0].foo).toBe(1)
+    // has
+    expect(0 in observed).toBe(true)
+    // ownKeys
+    expect(Object.keys(observed)).toEqual(['0'])
+  })
+
+  test('cloned reactive Array should point to observed values', () => {
+    const original = [{ foo: 1 }]
+    const observed = reactive(original)
+    const clone = observed.slice()
+    expect(isReactive(clone[0])).toBe(true)
+    expect(clone[0]).not.toBe(original[0])
+    expect(clone[0]).toBe(observed[0])
+  })
+
+  test('observed value should proxy mutations to original (Array)', () => {
+    const original: any[] = [{ foo: 1 }, { bar: 2 }]
+    const observed = reactive(original)
+    // set
+    const value = { baz: 3 }
+    const reactiveValue = reactive(value)
+    observed[0] = value
+    expect(observed[0]).toBe(reactiveValue)
+    expect(original[0]).toBe(value)
+    // delete
+    delete observed[0]
+    expect(observed[0]).toBeUndefined()
+    expect(original[0]).toBeUndefined()
+    // mutating methods
+    observed.push(value)
+    expect(observed[2]).toBe(reactiveValue)
+    expect(original[2]).toBe(value)
+  })
+
+  test('Array identity methods should work with raw values', () => {
+    const raw = {}
+    const arr = reactive([{}, {}])
+    arr.push(raw)
+    expect(arr.indexOf(raw)).toBe(2)
+    expect(arr.indexOf(raw, 3)).toBe(-1)
+    expect(arr.includes(raw)).toBe(true)
+    expect(arr.includes(raw, 3)).toBe(false)
+    expect(arr.lastIndexOf(raw)).toBe(2)
+    expect(arr.lastIndexOf(raw, 1)).toBe(-1)
+
+    // should work also for the observed version
+    const observed = arr[2]
+    expect(arr.indexOf(observed)).toBe(2)
+    expect(arr.indexOf(observed, 3)).toBe(-1)
+    expect(arr.includes(observed)).toBe(true)
+    expect(arr.includes(observed, 3)).toBe(false)
+    expect(arr.lastIndexOf(observed)).toBe(2)
+    expect(arr.lastIndexOf(observed, 1)).toBe(-1)
+  })
+
+  test('Array identity methods should work if raw value contains reactive objects', () => {
+    const raw = []
+    const obj = reactive({})
+    raw.push(obj)
+    const arr = reactive(raw)
+    expect(arr.includes(obj)).toBe(true)
+  })
+
+  test('Array identity methods should be reactive', () => {
+    const obj = {}
+    const arr = reactive([obj, {}])
+
+    let index: number = -1
+    watchEffect(
+      () => {
+        index = arr.indexOf(obj)
+      },
+      { flush: 'sync' }
+    )
+    expect(index).toBe(0)
+    arr.reverse()
+    expect(index).toBe(1)
+  })
+
+  test('delete on Array should not trigger length dependency', () => {
+    const arr = reactive([1, 2, 3])
+    const fn = jest.fn()
+    watchEffect(
+      () => {
+        fn(arr.length)
+      },
+      { flush: 'sync' }
+    )
+    expect(fn).toHaveBeenCalledTimes(1)
+    delete arr[1]
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  test('add existing index on Array should not trigger length dependency', () => {
+    const array = new Array(3)
+    const observed = reactive(array)
+    const fn = jest.fn()
+    watchEffect(
+      () => {
+        fn(observed.length)
+      },
+      { flush: 'sync' }
+    )
+    expect(fn).toHaveBeenCalledTimes(1)
+    observed[1] = 1
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  test('add non-integer prop on Array should not trigger length dependency', () => {
+    const array = new Array(3)
+    const observed = reactive(array)
+    const fn = jest.fn()
+    watchEffect(
+      () => {
+        fn(observed.length)
+      },
+      { flush: 'sync' }
+    )
+    expect(fn).toHaveBeenCalledTimes(1)
+    // @ts-ignore
+    observed.x = 'x'
+    expect(fn).toHaveBeenCalledTimes(1)
+    observed[-1] = 'x'
+    expect(fn).toHaveBeenCalledTimes(1)
+    observed[NaN] = 'x'
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  describe('Array methods w/ refs', () => {
+    let original: any[]
+    beforeEach(() => {
+      original = reactive([1, ref(2)])
+    })
+
+    // read + copy
+    test('read only copy methods', () => {
+      const res = original.concat([3, ref(4)])
+      const raw = toRaw(res)
+      expect(isRef(raw[1])).toBe(true)
+      expect(isRef(raw[3])).toBe(true)
+    })
+
+    // read + write
+    test('read + write mutating methods', () => {
+      const res = original.copyWithin(0, 1, 2)
+      const raw = toRaw(res)
+      expect(isRef(raw[0])).toBe(true)
+      expect(isRef(raw[1])).toBe(true)
+    })
+
+    test('read + identity', () => {
+      const ref = original[1]
+      expect(ref).toBe(toRaw(original)[1])
+      expect(original.indexOf(ref)).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
There's a few issues with the array and `computed`, might be better to have a "soft" support, we rollback the `readme.md` to have the array is not supported. 

To have a decent implementation we need to have the `effect` working with a better dependency tracking.