### PR TITLE
fix(vue-test): prevent warning when using multiple `localVue`

### DIFF
--- a/src/runtimeContext.ts
+++ b/src/runtimeContext.ts
@@ -46,7 +46,8 @@ export function getRegisteredVueOrDefault(): VueConstructor {
 }
 
 export function setVueConstructor(Vue: VueConstructor) {
-  if (__DEV__ && vueConstructor) {
+  // @ts-ignore
+  if (__DEV__ && vueConstructor && Vue.__proto__ !== vueConstructor.__proto__) {
     warn('Another instance of vue installed')
   }
   vueConstructor = Vue

--- a/test/use.spec.ts
+++ b/test/use.spec.ts
@@ -1,3 +1,4 @@
+import Vue from 'vue'
 import CompositionApi from '../src'
 import { createLocalVue } from './helpers/create-local-vue'
 import { mockWarn } from './helpers'
@@ -12,7 +13,26 @@ describe('use', () => {
     const localVueTwo = createLocalVue()
     localVueTwo.use(CompositionApi)
 
-    expect('Another instance of vue installed').toHaveBeenWarned()
+    expect('Another instance of vue installed').not.toHaveBeenWarned()
+  })
+
+  it('should warn install in multiple vue', () => {
+    try {
+      const fakeVue = {
+        version: '2._.x',
+        config: {
+          optionMergeStrategies: {},
+        },
+        mixin: jest.fn(),
+      }
+
+      // @ts-ignore
+      CompositionApi.install(fakeVue)
+      expect('Another instance of vue installed').toHaveBeenWarned()
+    } finally {
+      Vue.use(CompositionApi)
+      expect('Another instance of vue installed').toHaveBeenWarned()
+    }
   })
 
   it('should warn installing multiple times', () => {
@@ -29,7 +49,5 @@ describe('use', () => {
     }).toThrowError(
       'already installed. Vue.use(VueCompositionAPI) should be called only once.'
     )
-
-    expect('Another instance of vue installed').toHaveBeenWarned()
   })
 })


### PR DESCRIPTION
fix #530 