### PR TITLE
fix: Support multiple `composition-api` in one `VueConstructor`

### DIFF
--- a/src/runtimeContext.ts
+++ b/src/runtimeContext.ts
@@ -13,7 +13,8 @@ try {
 let vueConstructor: VueConstructor | null = null
 let currentInstance: ComponentInstance | null = null
 
-const PluginInstalledFlag = '__composition_api_installed__'
+const randomStr = Math.random().toString(36).substring(2, 15) // Support multiple `composition-api` in one `VueConstructor`
+const PluginInstalledFlag = `__composition_api_${randomStr}_installed__`
 
 export function isPluginInstalled() {
   return !!vueConstructor


### PR DESCRIPTION
I think that the mechanism that does not allow duplicate registration should be for the same project. 
But there are actually such situations like: two projects share the same `VueConstructor` but use two different composition-api.

This pr solves this problem by adding a random value to the flag.
