### PR TITLE
fix: add emits options to defineComponent(fix #553)

### DIFF
--- a/src/component/componentOptions.ts
+++ b/src/component/componentOptions.ts
@@ -70,6 +70,7 @@ export type ComponentOptionsWithProps<
   Props = ExtractPropTypes<PropsOptions>
 > = ComponentOptionsBase<Props, D, C, M> & {
   props?: PropsOptions
+  emits?: string[] | Record<string, null | ((emitData: any) => boolean) >
   setup?: SetupFunction<Props, RawBindings>
 } & ThisType<ComponentRenderProxy<Props, RawBindings, D, C, M>>
 
@@ -82,6 +83,7 @@ export type ComponentOptionsWithArrayProps<
   Props = Readonly<{ [key in PropNames]?: any }>
 > = ComponentOptionsBase<Props, D, C, M> & {
   props?: PropNames[]
+  emits?: string[] | Record<string, null | ((emitData: any) => boolean)>
   setup?: SetupFunction<Props, RawBindings>
 } & ThisType<ComponentRenderProxy<Props, RawBindings, D, C, M>>
 
@@ -93,6 +95,7 @@ export type ComponentOptionsWithoutProps<
   M extends MethodOptions = {}
 > = ComponentOptionsBase<Props, D, C, M> & {
   props?: undefined
+  emits?: string[] | Record<string, null | ((emitData: any) => boolean)>
   setup?: SetupFunction<Props, RawBindings>
 } & ThisType<ComponentRenderProxy<Props, RawBindings, D, C, M>>
 


### PR DESCRIPTION
https://v3.vuejs.org/guide/component-custom-events.html#defining-custom-events

https://eslint.vuejs.org/rules/require-explicit-emits.html

> TIP
>
> It is recommended to define all emitted events in order to better document how a component should work.

Though it has no effects on Vue2, but we can still add `emits: string[] | Record<string, null | ((emitData: any) => boolean) >` in `defineComponent` for better documenting and to avoid eslint-plugin-vue@V7 throwing warnings.

Also, we have to warn people in readme that this has **no effects for validating the emit event** and just for smoothing the miragation.

---

Adding `emits` options will broke ThisType in defineComponent now.

![image](https://user-images.githubusercontent.com/33315834/95433782-0558bf00-0983-11eb-80bc-2cb7032c2bb9.png)

![image](https://user-images.githubusercontent.com/33315834/95433602-bdd23300-0982-11eb-867e-fe3d390076be.png)

while eslint will throw warnings if using `vue/require-explicit-emits`

![image](https://user-images.githubusercontent.com/33315834/95433689-de01f200-0982-11eb-9e7e-60f827af527c.png)
