### PR TITLE
feat: add short hand function: supply, infuse

### DIFF
--- a/src/apis/inject.ts
+++ b/src/apis/inject.ts
@@ -82,7 +82,8 @@ export function supply<T extends Data = Data>(
   const data = <ToRefs<T>>{}
 
   const setValue = (item: any, key: any) => {
-    const value = toRef(item, key)
+    const raw = item[key]
+    const value = isFunction(raw) ? raw : toRef(item, key)
     provide(key, value)
     set(data, key, inject(key))
   }

--- a/src/apis/inject.ts
+++ b/src/apis/inject.ts
@@ -1,9 +1,13 @@
-import { ComponentInstance } from '../component'
+import { ComponentInstance, Data } from '../component'
 import { hasOwn, warn, currentVMInFn, isFunction } from '../utils'
 import { getCurrentInstance } from '../runtimeContext'
+import { reactive, set, toRef, UnwrapRef, ToRefs } from '../reactivity'
 
 const NOT_FOUND = {}
 export interface InjectionKey<T> extends Symbol {}
+export type InjectKey = symbol | string
+export type ProvideRecord = Record<InjectKey, any>
+export type InjectRecord = Record<InjectKey, InjectKey> | Array<InjectKey>
 
 function resolveInject(
   provideKey: InjectionKey<any> | string,
@@ -70,4 +74,40 @@ export function inject(
   return treatDefaultAsFactory && isFunction(defaultValue)
     ? defaultValue()
     : defaultValue
+}
+
+export function supply<T extends Data = Data>(
+  ...items: ProvideRecord[]
+): ToRefs<T> {
+  const data = <ToRefs<T>>{}
+
+  const setValue = (item: any, key: any) => {
+    const value = toRef(item, key)
+    provide(key, value)
+    set(data, key, inject(key))
+  }
+
+  items.forEach((item: ProvideRecord) => {
+    Object.getOwnPropertySymbols(item).forEach((key) => setValue(item, key))
+    Object.keys(item).forEach((key) => setValue(item, key))
+  })
+
+  return data
+}
+
+export function infuse(...items: InjectRecord[]): UnwrapRef<ProvideRecord> {
+  const data = reactive<ProvideRecord>({})
+
+  const setValue = (key: any) => set(data, key, inject(key))
+
+  items.forEach((item: InjectRecord) => {
+    if (Array.isArray(item)) {
+      item.forEach(setValue)
+    } else {
+      Object.getOwnPropertySymbols(item).forEach(setValue)
+      Object.keys(item).forEach(setValue)
+    }
+  })
+
+  return data
 }

--- a/src/reactivity/index.ts
+++ b/src/reactivity/index.ts
@@ -15,6 +15,7 @@ export {
   Ref,
   createRef,
   UnwrapRef,
+  ToRefs,
   toRefs,
   toRef,
   unref,


### PR DESCRIPTION
I add two short hand function.

**supploy**
for provide multi-set refs (also can for return to template)

```ts
setup() {
  const a = ref('a');
  const b = ref('b');
  const state = reactive({ a, b });
  provide('a', a);
  provide('b', b);
  return { ...toRefs(state) };
}
```

equals

```ts
setup() {
  const a = ref('a');
  const b = ref('b');
  const state = reactive({ a, b });
  return { ...supply(state) };
}
```

**infuse**
for inject multi-set refs

```ts
setup() {
  const state = reactive({ a1: inject('a'), b1: inject('b') });
}
```

equals

```ts
setup() {
  const state = infuse({ a1: 'a', b1: 'b' });
}
```
