### PR TITLE
types(defineComponent): fix options API support when using defineComponent

### DIFF
--- a/src/component/componentProxy.ts
+++ b/src/component/componentProxy.ts
@@ -41,13 +41,19 @@ export type ComponentRenderProxy<
   Omit<Vue, '$data' | '$props' | '$attrs'>
 
 // for Vetur and TSX support
-type VueConstructorProxy<PropsOptions, RawBindings> = VueConstructor & {
+type VueConstructorProxy<
+  PropsOptions,
+  RawBindings,
+  Data,
+  Computed extends ComputedOptions,
+  Methods extends MethodOptions
+> = VueConstructor & {
   new (...args: any[]): ComponentRenderProxy<
     ExtractPropTypes<PropsOptions>,
     ShallowUnwrapRef<RawBindings>,
-    ExtractPropTypes<PropsOptions>,
-    {},
-    {},
+    Data,
+    Computed,
+    Methods,
     ExtractPropTypes<PropsOptions>,
     ExtractDefaultPropTypes<PropsOptions>,
     true
@@ -62,8 +68,8 @@ export type VueProxy<
   PropsOptions,
   RawBindings,
   Data = DefaultData<Vue>,
-  Computed = DefaultComputed,
-  Methods = DefaultMethods<Vue>
+  Computed extends ComputedOptions = DefaultComputed,
+  Methods extends MethodOptions = DefaultMethods<Vue>
 > = Vue2ComponentOptions<
   Vue,
   ShallowUnwrapRef<RawBindings> & Data,
@@ -72,4 +78,4 @@ export type VueProxy<
   PropsOptions,
   ExtractPropTypes<PropsOptions>
 > &
-  VueConstructorProxy<PropsOptions, RawBindings>
+  VueConstructorProxy<PropsOptions, RawBindings, Data, Computed, Methods>

--- a/test-dts/defineComponent.test-d.ts
+++ b/test-dts/defineComponent.test-d.ts
@@ -667,3 +667,41 @@ describe('emits', () => {
   })
   */
 })
+
+describe('vetur', () => {
+  // #609
+  it('should have access to options API', () => {
+    const Comp = defineComponent({
+      data() {
+        return {
+          a: 1,
+        }
+      },
+
+      computed: {
+        ac() {
+          return 1
+        },
+      },
+
+      methods: {
+        callA(b: number) {
+          return b
+        },
+      },
+
+      setup() {
+        return {
+          sa: '1',
+        }
+      },
+    })
+
+    const comp = new Comp()
+
+    expectType<number>(comp.a)
+    expectType<number>(comp.ac)
+    expectType<string>(comp.sa)
+    expectType<(b: number) => number>(comp.callA)
+  })
+})


### PR DESCRIPTION
fix #609