### PR TITLE
docs: SetupContext.refs type, remove unnecessary docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ import Vue from 'vue'
 
 declare module '@vue/composition-api' {
   interface SetupContext {
-    readonly refs: { [key: string]: Vue | Element | Vue[] | Element[] }
+    readonly refs: { [key: string]: unknown };
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -368,18 +368,6 @@ export default {
 }
 ```
 
-You may also need to augment the `SetupContext` when working with TypeScript:
-
-```ts
-import Vue from 'vue'
-
-declare module '@vue/composition-api' {
-  interface SetupContext {
-    readonly refs: { [key: string]: unknown };
-  }
-}
-```
-
 </details>
 
 ### Reactive

--- a/src/component/componentOptions.ts
+++ b/src/component/componentOptions.ts
@@ -1,4 +1,4 @@
-import { VNode, ComponentOptions as Vue2ComponentOptions } from 'vue'
+import Vue, { VNode, ComponentOptions as Vue2ComponentOptions } from 'vue'
 import { Data } from './common'
 import { ComponentPropsOptions, ExtractPropTypes } from './componentProps'
 import { ComponentInstance, ComponentRenderProxy } from './componentProxy'
@@ -25,7 +25,7 @@ export interface SetupContext {
   /**
    * @deprecated not avaliable in Vue 3
    */
-  readonly refs: Data
+  readonly refs: { [key: string]: Vue | Element | Vue[] | Element[] }
 
   emit(event: string, ...args: any[]): void
 }


### PR DESCRIPTION
Fix docs bug introduced by https://github.com/vuejs/composition-api/pull/595

## Error

```
ERROR in /home/user/github.com/VIAME-Web/client/platform/web-girder/views/ViewerLoader.vue(16,14):
16:14 Subsequent property declarations must have the same type.  Property 'refs' must be of type 'Data', but here has type '{ [key: string]: Element | Element[] | Vue | Vue[]; }'.
    14 | declare module '@vue/composition-api' {
    15 |   interface SetupContext {
  > 16 |     readonly refs: { [key: string]: Vue | Element | Vue[] | Element[] }
       |              ^
    17 |   }
    18 | }
    19 | /**

```

Type of `refs` changed to unexported type `Data`.  I've verified that this change works on a local project.