### PR TITLE
refactor: remove expressions that is always false

### DIFF
--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -162,12 +162,6 @@ export function shallowReactive(obj: any): any {
       }
       getter = property.get
       setter = property.set
-      if (
-        (!getter || setter) /* not only have getter */ &&
-        arguments.length === 2
-      ) {
-        val = obj[key]
-      }
     }
 
     Object.defineProperty(observed, key, {

--- a/src/reactivity/readonly.ts
+++ b/src/reactivity/readonly.ts
@@ -59,20 +59,12 @@ export function shallowReadonly(obj: any): any {
   for (const key of Object.keys(obj)) {
     let val = obj[key]
     let getter: (() => any) | undefined
-    let setter: ((x: any) => void) | undefined
     const property = Object.getOwnPropertyDescriptor(obj, key)
     if (property) {
       if (property.configurable === false) {
         continue
       }
       getter = property.get
-      setter = property.set
-      if (
-        (!getter || setter) /* not only have getter */ &&
-        arguments.length === 2
-      ) {
-        val = obj[key]
-      }
     }
 
     Object.defineProperty(readonlyObj, key, {


### PR DESCRIPTION
`shallowReactive` and `shallowReadonly` have only one argument, so `arguments.length === 2` is always `false`.