### PR TITLE
fix(reactive): align behavior with vue-next

### DIFF
--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -1,6 +1,14 @@
 import { AnyObject } from '../types/basic'
 import { getRegisteredVueOrDefault } from '../runtimeContext'
-import { isPlainObject, def, warn, isArray, hasOwn, noopFn } from '../utils'
+import {
+  isPlainObject,
+  def,
+  warn,
+  isArray,
+  hasOwn,
+  noopFn,
+  isObject,
+} from '../utils'
 import { isComponentInstance, defineComponentInstance } from '../utils/helper'
 import { RefKey } from '../utils/symbols'
 import { isRef, UnwrapRef } from './ref'
@@ -190,10 +198,11 @@ export function shallowReactive(obj: any): any {
  * Make obj reactivity
  */
 export function reactive<T extends object>(obj: T): UnwrapRef<T> {
-  if (__DEV__ && !obj) {
-    warn('"reactive()" is called without provide an "object".')
-    // @ts-ignore
-    return
+  if (!isObject(obj)) {
+    if (__DEV__) {
+      warn('"reactive()" is called without provide an "object".')
+    }
+    return obj as any
   }
 
   if (

--- a/test/v3/reactivity/reactive.spec.ts
+++ b/test/v3/reactivity/reactive.spec.ts
@@ -142,6 +142,7 @@ describe('reactivity/reactive', () => {
   test('non-observable values', () => {
     const assertValue = (value: any) => {
       expect(isReactive(reactive(value))).toBe(false)
+      expect(reactive(value)).toBe(value)
       // expect(warnSpy).toHaveBeenLastCalledWith(`value cannot be made reactive: ${String(value)}`);
     }
 
@@ -167,7 +168,7 @@ describe('reactivity/reactive', () => {
     const d = new Date()
     expect(reactive(d)).toBe(d)
 
-    expect(warn).toBeCalledTimes(3)
+    expect(warn).toBeCalledTimes(12)
     expect(
       warn.mock.calls.map((call) => {
         expect(call[0]).toBe(


### PR DESCRIPTION
Keep consistent with `vue-next`:

https://github.com/vuejs/vue-next/blob/d3d9355c5a75675ab99ff8bb381e34d02e322e88/packages/reactivity/src/reactive.ts#L180-L185