### PR TITLE
docs(README): update unwrap ref in an array limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,27 +122,6 @@ export default {
 
 ### `Ref` Unwrap
 
-`Unwrap` is not working with Array index.
-
-<details>
-<summary>
-❌ <b>Should NOT</b> store <code>ref</code> as a <b>direct</b> child of <code>Array</code>
-</summary>
-
-```js
-const state = reactive({
-  list: [ref(0)],
-})
-// no unwrap, `.value` is required
-state.list[0].value === 0 // true
-
-state.list.push(ref(1))
-// no unwrap, `.value` is required
-state.list[1].value === 1 // true
-```
-
-</details>
-
 <details>
 <summary>
 ❌ <b>Should NOT</b> use <code>ref</code> in a plain object when working with <code>Array</code>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -117,27 +117,6 @@ export default {
 
 ### `Ref` 自动展开 (unwrap)
 
-数组索引属性无法进行自动展开:
-
-<details>
-<summary>
-❌ <b>不要</b> 使用数组直接存取 <code>ref</code> 对象
-</summary>
-
-```js
-const state = reactive({
-  list: [ref(0)],
-})
-// 不会自动展开, 须使用 `.value`
-state.list[0].value === 0 // true
-
-state.list.push(ref(1))
-// 不会自动展开, 须使用 `.value`
-state.list[1].value === 1 // true
-```
-
-</details>
-
 <details>
 <summary>
 ❌ <b>不要</b> 在数组中使用含有 <code>ref</code> 的普通对象


### PR DESCRIPTION
Refs do not unwrap in a reactive array or nested array of a reactive object since 3.0.0-alpha.6 version. Hence, there are not limitations. See issue: https://github.com/vuejs/vue-next/issues/737