### PR TITLE
docs(README): synchronize limitation text and code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,8 +427,8 @@ app2.component('Bar', Bar) // equivalent to Vue.use('Bar', Bar)
 
 <details>
 <summary>
-⚠️ <code>toRefs(props.foo.bar)</code> will incorrectly warn when acessing nested levels of props.
-⚠️ <code>isReactive(props.foo.bar)</code> will return false.
+⚠️ <code>toRefs(props.foo)</code> will incorrectly warn when accessing nested levels of props. <br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;⚠️ <code>isReactive(props.foo)</code> will return false.
 </summary>
 
 ```ts

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -410,8 +410,8 @@ watch(
 
 <details>
 <summary>
-⚠️ 当使用 <code>toRefs</code> 访问深层属性对象 （如 <code>toRefs(props.foo.bar)</code> 时将会得到不正确的警告。
-⚠️ <code>isReactive(props.foo.bar)</code> 将会返回 false。
+⚠️ 当使用 <code>toRefs</code> 访问深层属性对象 （如 <code>toRefs(props.foo)</code> 时将会得到不正确的警告。<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;⚠️ <code>isReactive(props.foo)</code> 将会返回 false。
 </summary>
   
 ```ts


### PR DESCRIPTION
The limitation text looks a bit confusing when you look at the sample code. The warning icon hanging at the end of the line looks strange. I've moved it to the next line and added an indent.