### PR TITLE
docs(README): remove extra indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ app2.component('Bar', Bar) // equivalent to Vue.use('Bar', Bar)
 <details>
 <summary>
 ⚠️ <code>toRefs(props.foo)</code> will incorrectly warn when accessing nested levels of props. <br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;⚠️ <code>isReactive(props.foo)</code> will return false.
+&nbsp;&nbsp;&nbsp;&nbsp;⚠️ <code>isReactive(props.foo)</code> will return false.
 </summary>
 
 ```ts


### PR DESCRIPTION
Sorry, in GitHub Markdown the icons are not aligned😅 Removed the extra indent and aligned the two icons
![image](https://user-images.githubusercontent.com/47852810/119275555-769d6780-bc1e-11eb-840b-46a98f5111b1.png)