### PR TITLE
fix(watch): align behavior with vue-next(doWatch).

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -60,6 +60,17 @@ export function isArray<T>(x: unknown): x is T[] {
   return Array.isArray(x)
 }
 
+export const objectToString = Object.prototype.toString
+
+export const toTypeString = (value: unknown): string =>
+  objectToString.call(value)
+
+export const isMap = (val: unknown): val is Map<any, any> =>
+  toTypeString(val) === '[object Map]'
+
+export const isSet = (val: unknown): val is Set<any> =>
+  toTypeString(val) === '[object Set]'
+
 export function isValidArrayIndex(val: any): boolean {
   const n = parseFloat(String(val))
   return n >= 0 && Math.floor(n) === n && isFinite(val)


### PR DESCRIPTION
This PR can solve the problem of not triggering `watch` callbacks in the following scenarios，keep the same behavior with vue-next.

```
<template>
  <div id="app">
    <div>{{ count[0] }}</div>
    <button @click="change">jml</button>
  </div>
</template>

<script>
import {watch,set, reactive} from '@vue/composition-api'

export default {
  name: "App",  
  setup() {
    const count = reactive(["sdfs"])
    const change = ()=>{
      set(count, 0, "222")
    }
    watch(count,()=>{console.log("xxxxx");},{deep: true}
    )
    return {count,change};
  },
};
</script>

<style>
#app {
  font-family: Avenir, Helvetica, Arial, sans-serif;
  -webkit-font-smoothing: antialiased;
  -moz-osx-font-smoothing: grayscale;
  text-align: center;
  color: #2c3e50;
  margin-top: 60px;
}
</style>
```