### PR TITLE
feat(reactivity): unwrap value when using `set`

### DIFF
--- a/src/reactivity/set.ts
+++ b/src/reactivity/set.ts
@@ -34,7 +34,8 @@ export function set<T>(target: any, key: any, val: T): T {
     return val
   }
   if (!ob) {
-    target[key] = val
+    // If we are using `set` we can assume that the unwrapping is intended
+    defineAccessControl(target, key, val)
     return val
   }
   defineReactive(ob.value, key, val)

--- a/test/ssr/ssrReactive.spec.ts
+++ b/test/ssr/ssrReactive.spec.ts
@@ -90,4 +90,16 @@ describe('SSR Reactive', () => {
 
     done()
   })
+
+  // #721
+  it('should behave correctly', () => {
+    const state = ref({ old: ref(false) })
+    set(state.value, 'new', ref(true))
+    // console.log(process.server, 'state.value', JSON.stringify(state.value))
+
+    expect(state.value).toMatchObject({
+      old: false,
+      new: true,
+    })
+  })
 })


### PR DESCRIPTION
fix #721


When using `set` if the object is not `reactive` it won't execute the unwrapping as per expected on a reactive object, in vue 2 every object used is expected to be `reactive` by default so I believe is safe to assume that if you calling `set` we will want to unwrap the value if is a `ref`