### PR TITLE
fix(observe): solve the Ref not unwrapping on the ssr side issue with recursive way.

### DIFF
--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -118,9 +118,28 @@ export function observe<T>(obj: T): T {
   // in SSR, there is no __ob__. Mock for reactivity check
   if (!hasOwn(observed, '__ob__')) {
     def(observed, '__ob__', mockObserver(observed))
+    walk(observed)
   }
 
   return observed
+}
+
+/**
+ * Recursive obj, add __ob__
+ */
+function walk(obj: any) {
+  var keys = Object.keys(obj)
+  for (let i = 0; i < keys.length; i++) {
+    if (
+      !(isPlainObject(obj[keys[i]]) || isArray(obj[keys[i]])) ||
+      isRaw(obj[keys[i]]) ||
+      !Object.isExtensible(obj[keys[i]])
+    ) {
+      continue
+    }
+    def(obj[keys[i]], '__ob__', mockObserver(obj[keys[i]]))
+    walk(obj[keys[i]])
+  }
 }
 
 export function createObserver() {

--- a/src/reactivity/set.ts
+++ b/src/reactivity/set.ts
@@ -40,8 +40,7 @@ export function set<T>(target: any, key: any, val: T): T {
     return val
   }
   if (!ob) {
-    // If we are using `set` we can assume that the unwrapping is intended
-    defineAccessControl(target, key, val)
+    target[key] = val
     return val
   }
   defineReactive(ob.value, key, val)

--- a/test/ssr/ssrReactive.spec.ts
+++ b/test/ssr/ssrReactive.spec.ts
@@ -102,4 +102,20 @@ describe('SSR Reactive', () => {
       new: true,
     })
   })
+
+  // #721
+  it('should behave correctly for the nested ref in the object', () => {
+    const state = { old: ref(false) }
+    set(state, 'new', ref(true))
+    expect(JSON.stringify(state)).toBe(
+      '{"old":{"value":false},"new":{"value":true}}'
+    )
+  })
+
+  // #721
+  it('should behave correctly for ref of object', () => {
+    const state = ref({ old: ref(false) })
+    set(state.value, 'new', ref(true))
+    expect(JSON.stringify(state.value)).toBe('{"old":false,"new":true}')
+  })
 })


### PR DESCRIPTION
Solving #721 with #722：
```
  it('result of #722', () => {
    const state = { old: ref(false) }
    set(state, 'new', ref(true))
    expect(JSON.stringify(state)).toBe(
      '{"old":{"value":false},"new":true}'  // 'old' is different from 'new'
    )
  })
```
the form of value of `old` key is different from `new` key.

if we solve #721 with recursive way:
```
  it('solving with recursive way', () => {
    const state = { old: ref(false) }
    set(state, 'new', ref(true))
    expect(JSON.stringify(state)).toBe(
      '{"old":{"value":false},"new":{"value":true}}'
    )
  })
```
for above case, should `{"old":{"value":false},"new":{"value":true}}` is more appropriate? @pikax @antfu Look forward your comments？
