### PR TITLE
fix(watch): watched previous values can't be destructure on first fire.

### DIFF
--- a/src/apis/watch.ts
+++ b/src/apis/watch.ts
@@ -329,6 +329,7 @@ function createWatcher(
     // The subsequent callbacks will redirect to `callback`.
     let shiftCallback = (n: any, o: any) => {
       shiftCallback = originalCallback
+      o = isArray(n) ? [] : undefined
       applyCb(n, o)
     }
     callback = (n: any, o: any) => {

--- a/src/apis/watch.ts
+++ b/src/apis/watch.ts
@@ -329,8 +329,8 @@ function createWatcher(
     // The subsequent callbacks will redirect to `callback`.
     let shiftCallback = (n: any, o: any) => {
       shiftCallback = originalCallback
-      o = isArray(n) ? [] : undefined
-      applyCb(n, o)
+      // o is undefined on the first call
+      applyCb(n, isArray(n) ? [] : o)
     }
     callback = (n: any, o: any) => {
       shiftCallback(n, o)

--- a/test/apis/watch.spec.js
+++ b/test/apis/watch.spec.js
@@ -457,7 +457,7 @@ describe('api/watch', () => {
         template: `<div>{{obj1.a}} {{obj2.a}}</div>`,
       }).$mount()
       expect(spy).toBeCalledTimes(1)
-      expect(spy).toHaveBeenLastCalledWith([1, 2], undefined)
+      expect(spy).toHaveBeenLastCalledWith([1, 2], [])
       obj1.a = 2
       obj2.a = 3
 
@@ -491,7 +491,7 @@ describe('api/watch', () => {
         template: `<div>{{a}} {{b}}</div>`,
       }).$mount()
       expect(spy).toBeCalledTimes(1)
-      expect(spy).toHaveBeenLastCalledWith([1, 1], undefined)
+      expect(spy).toHaveBeenLastCalledWith([1, 1], [])
       vm.a = 2
       expect(spy).toBeCalledTimes(1)
       waitForUpdate(() => {
@@ -553,7 +553,7 @@ describe('api/watch', () => {
         },
       })
       expect(spy).toBeCalledTimes(1)
-      expect(spy).toHaveBeenLastCalledWith([1, 1], undefined)
+      expect(spy).toHaveBeenLastCalledWith([1, 1], [])
       vm.a = 2
       expect(spy).toBeCalledTimes(2)
       expect(spy).toHaveBeenLastCalledWith([2, 1], [1, 1])


### PR DESCRIPTION
Fix: #418, align behavior with vue-next.
