### PR TITLE
fix(reactivity): check type of __ob__ in isRaw and isReactive

### DIFF
--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -15,11 +15,15 @@ import { isRef, UnwrapRef } from './ref'
 import { rawSet, accessModifiedSet } from '../utils/sets'
 
 export function isRaw(obj: any): boolean {
-  return Boolean(obj?.__ob__ && obj.__ob__?.__raw__)
+  return Boolean(
+    obj?.__ob__ && typeof obj.__ob__ === 'object' && obj.__ob__?.__raw__
+  )
 }
 
 export function isReactive(obj: any): boolean {
-  return Boolean(obj?.__ob__ && !obj.__ob__?.__raw__)
+  return Boolean(
+    obj?.__ob__ && typeof obj.__ob__ === 'object' && !obj.__ob__?.__raw__
+  )
 }
 
 /**

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -1169,4 +1169,28 @@ describe('setup', () => {
 
     expect(warn).not.toBeCalled()
   })
+
+  it('should work with mock objects', async () => {
+    const originalProxy = new Proxy(
+      {},
+      {
+        get() {
+          return jest.fn()
+        },
+      }
+    )
+
+    const opts = {
+      template: `<div/>`,
+      setup() {
+        return {
+          proxy: originalProxy,
+        }
+      },
+    }
+    const Constructor = Vue.extend(opts).extend({})
+
+    const vm = new Vue(Constructor).$mount()
+    expect(vm.proxy).toBe(originalProxy)
+  })
 })


### PR DESCRIPTION
fixes #715 

We should check the type of `__ob__` because in some cases it may be not an expected object, but, for example, a mock function, so the fact that `Boolean(!__ob__.__raw__) === true` does not necessarily indicate that the object is reactive