### PR TITLE
docs: use b tag insteads of markdown * syntax

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -399,7 +399,7 @@ watch(
 
 <details>
 <summary>
-⚠️ <code>readonly()</code> **只提供类型层面**的只读。
+⚠️ <code>readonly()</code> <b>只提供类型层面</b>的只读。
 </summary>
 
 `readonly()` 只在类型层面提供和 Vue 3 的对齐。在其返回值或其属性上使用 <code>isReadonly()</code> 检查的结果将无法保证。


### PR DESCRIPTION
use b tag insteads of markdown * syntax to  fix readme zh-CN version display error.