### PR TITLE
refactor: use utils proxy

### DIFF
--- a/src/utils/instance.ts
+++ b/src/utils/instance.ts
@@ -20,16 +20,14 @@ export function asVmProperty(
         },
       })
     } else {
-      Object.defineProperty(vm, propName, {
-        enumerable: true,
-        configurable: true,
+      proxy(vm, propName, {
         get: () => {
           if (isReactive(propValue)) {
             ;(propValue as any).__ob__.dep.depend()
           }
           return propValue
         },
-        set: (val) => {
+        set: (val: any) => {
           propValue = val
         },
       })


### PR DESCRIPTION
Since the proxy method in utils is used in this file, it can be used instead of Object.defineProperty