### PR TITLE
fix(watch): traverse refs in deep watch

### DIFF
--- a/src/apis/watch.ts
+++ b/src/apis/watch.ts
@@ -325,6 +325,11 @@ function createWatcher(
     __DEV__ && warnInvalidSource(source)
   }
 
+  if (deep) {
+    const baseGetter = getter
+    getter = () => traverse(baseGetter())
+  }
+
   const applyCb = (n: any, o: any) => {
     // cleanup before running cb again
     runCleanup()

--- a/src/apis/watch.ts
+++ b/src/apis/watch.ts
@@ -325,6 +325,7 @@ function createWatcher(
     __DEV__ && warnInvalidSource(source)
   }
 
+  // traverse refs in deep watch
   if (deep) {
     const baseGetter = getter
     getter = () => traverse(baseGetter())

--- a/test/v3/runtime-core/apiWatch.spec.ts
+++ b/test/v3/runtime-core/apiWatch.spec.ts
@@ -68,6 +68,31 @@ describe('api: watch', () => {
     expect(dummy).toMatchObject([1, 0])
   })
 
+  it('watching single source: array', async () => {
+    const array = reactive([] as number[])
+    const spy = jest.fn()
+    watch(array, spy)
+    array.push(1)
+    await nextTick()
+    expect(spy).toBeCalledTimes(1)
+    expect(spy).toBeCalledWith([1], expect.anything(), expect.anything())
+  })
+
+  it('should not fire if watched getter result did not change', async () => {
+    const spy = jest.fn()
+    const n = ref(0)
+    watch(() => n.value % 2, spy)
+
+    n.value++
+    await nextTick()
+    expect(spy).toBeCalledTimes(1)
+
+    n.value += 2
+    await nextTick()
+    // should not be called again because getter result did not change
+    expect(spy).toBeCalledTimes(1)
+  })
+
   it('watching single source: computed ref', async () => {
     const count = ref(0)
     const plus = computed(() => count.value + 1)
@@ -570,5 +595,16 @@ describe('api: watch', () => {
     )
 
     expect(data2.value).toMatchObject([1])
+  })
+
+  it('watching sources: ref<any[]>', async () => {
+    const foo = ref([1])
+    const spy = jest.fn()
+    watch(foo, () => {
+      spy()
+    })
+    foo.value = foo.value.slice()
+    await nextTick()
+    expect(spy).toBeCalledTimes(1)
   })
 })

--- a/test/v3/runtime-core/apiWatch.spec.ts
+++ b/test/v3/runtime-core/apiWatch.spec.ts
@@ -160,9 +160,30 @@ describe('api: watch', () => {
     ])
   })
 
+  it('watching multiple sources: reactive object (with automatic deep: true)', async () => {
+    const src = reactive({ count: 0 })
+    let dummy
+    watch([src], ([state]) => {
+      dummy = state
+      // assert types
+      state.count === 1
+    })
+    src.count++
+    await nextTick()
+    expect(dummy).toMatchObject({ count: 1 })
+  })
+
   it('warn invalid watch source', () => {
     // @ts-ignore
     watch(1, () => {})
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid watch source'),
+      expect.anything()
+    )
+  })
+
+  it('warn invalid watch source: multiple sources', () => {
+    watch([1], () => {})
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('Invalid watch source'),
       expect.anything()

--- a/test/v3/runtime-core/apiWatch.spec.ts
+++ b/test/v3/runtime-core/apiWatch.spec.ts
@@ -426,6 +426,25 @@ describe('api: watch', () => {
     // expect(dummy).toEqual([1, 2, 2, false]);
   })
 
+  it('watching deep ref', async () => {
+    const count = ref(0)
+    const double = computed(() => count.value * 2)
+    const state = reactive([count, double])
+
+    let dummy
+    watch(
+      () => state,
+      (state) => {
+        dummy = [state[0].value, state[1].value]
+      },
+      { deep: true }
+    )
+
+    count.value++
+    await nextTick()
+    expect(dummy).toEqual([1, 2])
+  })
+
   it('immediate', async () => {
     const count = ref(0)
     const cb = jest.fn()


### PR DESCRIPTION
- **fix(watch): traverse refs in deep watch**
```js
// example

const count = ref(0)
const double = computed(() => count.value * 2)
const state = reactive([count, double])

let dummy
watch(
    () => state,
    (state) => {
        dummy = [state[0].value, state[1].value]
    },
    { deep: true }
)

count.value++
console.log(dummy) // output undefined. (bug: refs in deep watch doesn't work)
```
- test(watch): add test cases for api:watch
- fix(types): watch types
