### PR TITLE
types: simplify the UnwrapNestedRefs

### DIFF
--- a/src/reactivity/index.ts
+++ b/src/reactivity/index.ts
@@ -22,5 +22,11 @@ export { readonly, isReadonly, shallowReadonly } from './readonly'
 export { set } from './set'
 export { del } from './del'
 
-export type { Ref, ToRefs, UnwrapRef, ShallowUnwrapRef } from './ref'
+export type {
+  Ref,
+  ToRefs,
+  UnwrapRef,
+  UnwrapRefSimple,
+  ShallowUnwrapRef,
+} from './ref'
 export type { DeepReadonly } from './readonly'

--- a/src/reactivity/readonly.ts
+++ b/src/reactivity/readonly.ts
@@ -1,4 +1,4 @@
-import { reactive, Ref, UnwrapRef } from '.'
+import { reactive, Ref, UnwrapRefSimple } from '.'
 import { isArray, isPlainObject, isObject, warn, proxy } from '../utils'
 import { readonlySet } from '../utils/sets'
 import { isReactive, observe } from './reactive'
@@ -33,7 +33,7 @@ export type DeepReadonly<T> = T extends Builtin
                   : Readonly<T>
 
 // only unwrap nested ref
-type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRef<T>
+type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRefSimple<T>
 
 /**
  * **In @vue/composition-api, `reactive` only provides type-level readonly check**

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -29,7 +29,11 @@ export type UnwrapRef<T> = T extends Ref<infer V>
   ? UnwrapRefSimple<V>
   : UnwrapRefSimple<T>
 
-type UnwrapRefSimple<T> = T extends Function | CollectionTypes | BaseTypes | Ref
+export type UnwrapRefSimple<T> = T extends
+  | Function
+  | CollectionTypes
+  | BaseTypes
+  | Ref
   ? T
   : T extends Array<any>
   ? { [K in keyof T]: UnwrapRefSimple<T[K]> }


### PR DESCRIPTION
align behavior with vue3

details see : [vue3 #4194](https://github.com/vuejs/vue-next/pull/4194/files)