### PR TITLE
fix: don't invoke Vue getters in setter

### DIFF
--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -94,14 +94,14 @@ export function defineAccessControl(target: AnyObject, key: any, val?: any) {
     set: function setterHandler(newVal: any) {
       if (getter && !setter) return
 
-      const value = getter ? getter.call(target) : val
       // If the key is equal to RefKey, skip the unwrap logic
       // If and only if "value" is ref and "newVal" is not a ref,
       // the assignment should be proxied to "value" ref.
-      if (key !== RefKey && isRef(value) && !isRef(newVal)) {
-        value.value = newVal
+      if (key !== RefKey && isRef(val) && !isRef(newVal)) {
+        val.value = newVal
       } else if (setter) {
         setter.call(target, newVal)
+        val = newVal
       } else {
         val = newVal
       }


### PR DESCRIPTION
This fixes the codepen in the OP of #498 as well as in the application I'm working on.

I'm hoping it's valid to keep the internal value up-to-date rather than invoking the getter each time: I'm unable to prove that hypothesis wrong. It does assume that `getter` will return the last value passed to `setter`, but Vue 2's reactive getter/setters do that. I ran the tests with logging if they are different, and verified that situation never happens in the tests.

I believe infinite loops can still happen if you create a reactive object directly (`reactive()` or `set()`) or indirectly (`obj.x = {}`) but this PR solves most of it.

Fixes #498