### PR TITLE
test: add failing test of isReactive

### DIFF
--- a/test/ssr/ssrReactive.spec.ts
+++ b/test/ssr/ssrReactive.spec.ts
@@ -57,6 +57,13 @@ describe('SSR Reactive', () => {
     expect(isRaw(state)).toBe(false)
   })
 
+  it('should work on objects sets with set()', () => {
+    const state = ref<any>({})
+    set(state.value, 'a', {})
+
+    expect(isReactive(state.value.a)).toBe(true)
+  })
+
   // #550
   it('props should work with set', async (done) => {
     let props: any


### PR DESCRIPTION
I only added the failing test because I don't know where this should be fixed. I imagine something related to `defineAccessControl()` but I couldn't figure it out yet so feel free to to add commits to the PRs or create a new one

Note the same code works in client and on Vue 3