### PR TITLE
bug(watch): don't leak memory in Options API hooks

### DIFF
--- a/src/apis/watch.ts
+++ b/src/apis/watch.ts
@@ -13,7 +13,7 @@ import {
   isMap,
 } from '../utils'
 import { defineComponentInstance } from '../utils/helper'
-import { getVueConstructor } from '../runtimeContext'
+import { getVueConstructor, getCurrentVue2Instance } from '../runtimeContext'
 import {
   WatcherPreFlushQueueKey,
   WatcherPostFlushQueueKey,
@@ -113,10 +113,15 @@ function getWatchEffectOption(options?: Partial<WatchOptions>): WatchOptions {
 function getWatcherVM() {
   let vm = getCurrentScopeVM()
   if (!vm) {
-    if (!fallbackVM) {
-      fallbackVM = defineComponentInstance(getVueConstructor())
+    vm = getCurrentVue2Instance() || undefined
+    if (!vm) {
+      if (!fallbackVM) {
+        fallbackVM = defineComponentInstance(getVueConstructor())
+      }
+      vm = fallbackVM
+    } else if (!hasWatchEnv(vm)) {
+      installWatchEnv(vm)
     }
-    vm = fallbackVM
   } else if (!hasWatchEnv(vm)) {
     installWatchEnv(vm)
   }

--- a/src/runtimeContext.ts
+++ b/src/runtimeContext.ts
@@ -29,6 +29,7 @@ try {
 
 let vueConstructor: VueConstructor | null = null
 let currentInstance: ComponentInternalInstance | null = null
+let currentVue2Instance: ComponentInstance | null = null
 let currentInstanceTracking = true
 
 const PluginInstalledFlag = '__composition_api_installed__'
@@ -95,6 +96,14 @@ export function withCurrentInstanceTrackingDisabled(fn: () => void) {
 }
 
 export function setCurrentVue2Instance(vm: ComponentInstance | null) {
+  currentVue2Instance = vm
+}
+
+export function getCurrentVue2Instance() {
+  return currentVue2Instance
+}
+
+export function setCurrentInstanceFromVue2(vm: ComponentInstance | null) {
   if (!currentInstanceTracking) return
   setCurrentInstance(vm ? toVue3ComponentInstance(vm) : vm)
 }

--- a/src/utils/instance.ts
+++ b/src/utils/instance.ts
@@ -3,7 +3,7 @@ import vmStateManager from './vmStateManager'
 import {
   setCurrentInstance,
   getCurrentInstance,
-  setCurrentVue2Instance,
+  setCurrentInstanceFromVue2,
 } from '../runtimeContext'
 import { Ref, isRef, isReactive } from '../apis'
 import { hasOwn, proxy, warn } from './utils'
@@ -134,7 +134,7 @@ export function activateCurrentInstance(
   onError?: (err: Error) => void
 ) {
   let preVm = getCurrentInstance()
-  setCurrentVue2Instance(vm)
+  setCurrentInstanceFromVue2(vm)
   try {
     return fn(vm)
   } catch (err) {

--- a/test/apis/watch.spec.js
+++ b/test/apis/watch.spec.js
@@ -684,6 +684,33 @@ describe('api/watch', () => {
         })
         .then(done)
     })
+
+    it('should get destroyed with the active vm', (done) => {
+      const vm = new Vue({
+        data: { a: 1 },
+        created() {
+          watch(
+            () => this.a,
+            (n, o) => spy(n, o)
+          )
+        },
+        template: '<div>{{a}}</div>',
+      }).$mount()
+
+      vm.a = 2
+
+      waitForUpdate(() => {
+        expect(spy).toBeCalledTimes(1)
+      })
+        .then(() => {
+          vm.$destroy()
+          vm.a = 3
+        })
+        .then(() => {
+          expect(spy).toBeCalledTimes(1)
+        })
+        .then(done)
+    })
   })
 
   describe('cleanup', () => {


### PR DESCRIPTION
Tracks Vue 2 active instances by adding to the start and end of the hook list in `beforeCreate`, if there are any hooks there (if there are any hooks check is for performance). Adds a check in watch functions for a Vue 2 instance if there isn't one in effect scope or one for `setup()`.

I could also re-use the existing `activeInstance` mechanism, but that creates a whole Vue 3-like instance so it could slow down components with hooks.

Fixes #797