### PR TITLE
docs: Update required typescript version

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const { ref, reactive } = VueCompositionAPI
 
 ## TypeScript Support
 
-> TypeScript version **>3.5.1** is required
+> TypeScript version **>3.7** is required
 
 To let TypeScript properly infer types inside Vue component options, you need to define components with `defineComponent`
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const { ref, reactive } = VueCompositionAPI
 
 ## TypeScript Support
 
-> TypeScript version **>3.7** is required
+> TypeScript version **>4.2** is required
 
 To let TypeScript properly infer types inside Vue component options, you need to define components with `defineComponent`
 


### PR DESCRIPTION
This plugin relies on Typescript "Recursive Type Aliases" improvement, which was  released with Typescript 3.7:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#more-recursive-type-aliases

If used with Typescript 3.5.1 (the version specified in docs), typescript would throw the following error:

```
251:14 Type alias 'DeepReadonly' circularly references itself.
    249 | declare type Primitive = string | number | boolean | bigint | symbol | undefined | null;
    250 | declare type Builtin = Primitive | Function | Date | Error | RegExp;
  > 251 | declare type DeepReadonly<T> = T extends Builtin ? T : T extends Map<infer K, infer V> ? ReadonlyMap<DeepReadonly<K>, DeepReadonly<V>> : T extends ReadonlyMap<infer K, infer V> ? ReadonlyMap<DeepReadonly<K>, DeepReadonly<V>> : T extends WeakMap<infer K, infer V> ? WeakMap<DeepReadonly<K>, DeepReadonly<V>> : T extends Set<infer U> ? ReadonlySet<DeepReadonly<U>> : T extends ReadonlySet<infer U> ? ReadonlySet<DeepReadonly<U>> : T extends WeakSet<infer U> ? WeakSet<DeepReadonly<U>> : T extends Promise<infer U> ? Promise<DeepReadonly<U>> : T extends {} ? {
        |              ^
    252 |     readonly [K in keyof T]: DeepReadonly<T[K]>;
    253 | } : Readonly<T>;
    254 | declare type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRefSimple<T>;
```

This PR changes the required Typescript version in readme.