### PR TITLE
fix(api-watch): watching nested ref array w/ deep doesn't work

### DIFF
--- a/src/apis/watch.ts
+++ b/src/apis/watch.ts
@@ -341,7 +341,11 @@ function createWatcher(
   }
 
   const applyCb = (n: any, o: any) => {
-    if (isMultiSource && n.every((v: any, i: number) => Object.is(v, o[i])))
+    if (
+      !deep &&
+      isMultiSource &&
+      n.every((v: any, i: number) => Object.is(v, o[i]))
+    )
       return
     // cleanup before running cb again
     runCleanup()

--- a/test/v3/runtime-core/apiWatch.spec.ts
+++ b/test/v3/runtime-core/apiWatch.spec.ts
@@ -572,4 +572,14 @@ describe('api: watch', () => {
     await nextTick()
     expect(dummy).toEqual([1, 2])
   })
+
+  // #805 #807
+  it('watching sources: [ref<[]>] w/ deep', async () => {
+    const foo = ref([1])
+    const cb = jest.fn()
+    watch([foo], cb, { deep: true })
+    foo.value.push(2)
+    await nextTick()
+    expect(cb).toBeCalledTimes(1)
+  })
 })


### PR DESCRIPTION
close #805 

I personally think that the combination of the `Reactivity` API with the `Watch` API provides great flexibility, but also leads to very complex boundary condition handling, so perhaps the best we can do now is to find and solve problems to achieve higher test coverage～