### PR TITLE
fix: importing from esm in node

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "types": "./dist/vue-composition-api.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/vue-composition-api.esm.js",
+      "import": "./dist/vue-composition-api.mjs",
       "require": "./index.js"
     },
     "./*": "./*"


### PR DESCRIPTION
Right now you can't `import {watch} from "@vue/composition-api"` in nodejs from a `.mjs` file. If you try that, you'll get:

```
file:///Users/caleb/Code/temp/x.mjs:1
import {ref} from "@vue/composition-api";
        ^^^
SyntaxError: Named export 'ref' not found. The requested module '@vue/composition-api' is a CommonJS module, which may not support all module.exports as named exports.
```

I think since there's no `"type"` in package.json, the default module type for any `.js` is CJS. The files in the red and the green appear to be identical so I think this is low-risk and the right way to do it. As I understand it Webpack will parse anything, it doesn't really have a concept of module type, and not sure about other bundlers.