### PR TITLE
fix(proxyRefs): When using proxyRefs, the internal variable composition-api.refKey is exposed on the object itself #817

### DIFF
--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -1,5 +1,5 @@
 import { RefKey } from '../utils/symbols'
-import { proxy, isPlainObject, warn } from '../utils'
+import { proxy, isPlainObject, warn, def } from '../utils'
 import { reactive, isReactive, shallowReactive } from './reactive'
 import { readonlySet } from '../utils/sets'
 
@@ -171,6 +171,8 @@ export function proxyRefs<T extends object>(
     return objectWithRefs as ShallowUnwrapRef<T>
   }
   const value: Record<string, any> = reactive({ [RefKey]: objectWithRefs })
+
+  def(value, RefKey, value[RefKey], false)
 
   for (const key of Object.keys(objectWithRefs)) {
     proxy(value, key, {

--- a/test/v3/reactivity/ref.spec.ts
+++ b/test/v3/reactivity/ref.spec.ts
@@ -13,7 +13,9 @@ import {
   isReactive,
   shallowRef,
   proxyRefs,
+  ShallowUnwrapRef,
 } from '../../../src'
+import { RefKey } from '../../../src/utils/symbols'
 
 describe('reactivity/ref', () => {
   it('should hold a value', () => {
@@ -379,19 +381,28 @@ describe('reactivity/ref', () => {
         y: ref('foo'),
       },
     }
-    const p = proxyRefs(a)
+    const reactiveA = {
+      [RefKey]: a,
+      ...a,
+    }
+    const p = proxyRefs(a) as ShallowUnwrapRef<typeof reactiveA>
     expect(p.x).toBe(1)
     expect(p.obj.y).toBe('foo')
+    expect(p[RefKey]).toBe(a)
+    expect(Object.keys(p)).toStrictEqual(['x', 'obj'])
 
     // @ts-expect-error
     p.obj.y = 'bar'
     p.x = 2
     expect(a.x).toBe(2)
     expect(a.obj.y).toBe('bar')
+    expect(p[RefKey]).toBe(a)
+    expect(Object.keys(p)).toStrictEqual(['x', 'obj'])
 
     const r = reactive({ k: 'v' })
     const s = proxyRefs(r)
     expect(s.k).toBe('v')
+    expect(s[RefKey])
 
     r.k = 'k'
     expect(s.k).toBe('k')

--- a/test/v3/reactivity/ref.spec.ts
+++ b/test/v3/reactivity/ref.spec.ts
@@ -402,7 +402,6 @@ describe('reactivity/ref', () => {
     const r = reactive({ k: 'v' })
     const s = proxyRefs(r)
     expect(s.k).toBe('v')
-    expect(s[RefKey])
 
     r.k = 'k'
     expect(s.k).toBe('k')


### PR DESCRIPTION
fix [#817](https://github.com/vuejs/composition-api/issues/817)