### PR TITLE
fix: add `type` to component instance

### DIFF
--- a/src/runtimeContext.ts
+++ b/src/runtimeContext.ts
@@ -239,6 +239,7 @@ export function toVue3ComponentInstance(
   const instance: ComponentInternalInstance = {
     proxy: vm,
     update: vm.$forceUpdate,
+    type: vm.$options,
     uid: vm._uid,
 
     // $emit is defined on prototype and it expected to be bound

--- a/src/runtimeContext.ts
+++ b/src/runtimeContext.ts
@@ -174,7 +174,7 @@ export interface ComponentPublicInstance {}
  */
 export declare interface ComponentInternalInstance {
   uid: number
-  // type: ConcreteComponent
+  type: Record<string, unknown> // ConcreteComponent
   parent: ComponentInternalInstance | null
   root: ComponentInternalInstance
 
@@ -236,7 +236,7 @@ export function toVue3ComponentInstance(
     return instanceMapCache.get(vm)!
   }
 
-  const instance: ComponentInternalInstance = {
+  const instance: ComponentInternalInstance = ({
     proxy: vm,
     update: vm.$forceUpdate,
     type: vm.$options,
@@ -247,7 +247,7 @@ export function toVue3ComponentInstance(
 
     parent: null,
     root: null!, // to be immediately set
-  } as unknown as ComponentInternalInstance
+  } as unknown) as ComponentInternalInstance
 
   bindCurrentScopeToVM(instance)
 

--- a/src/runtimeContext.ts
+++ b/src/runtimeContext.ts
@@ -236,7 +236,7 @@ export function toVue3ComponentInstance(
     return instanceMapCache.get(vm)!
   }
 
-  const instance: ComponentInternalInstance = ({
+  const instance: ComponentInternalInstance = {
     proxy: vm,
     update: vm.$forceUpdate,
     type: vm.$options,
@@ -247,7 +247,7 @@ export function toVue3ComponentInstance(
 
     parent: null,
     root: null!, // to be immediately set
-  } as unknown) as ComponentInternalInstance
+  } as unknown as ComponentInternalInstance
 
   bindCurrentScopeToVM(instance)
 


### PR DESCRIPTION
Resolves https://github.com/vuejs/composition-api/issues/827

This PR adds compatibility support for `vm.type`.