### PR TITLE
Return a more reasonable type for arrays

### DIFF
--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -49,7 +49,7 @@ export type UnwrapRefSimple<T> = T extends
   | Ref
   ? T
   : T extends Array<any>
-  ? { [K in keyof T]: UnwrapRefSimple<T[K]> }
+  ? Array<UnwrapRefSimple<T[number]>>
   : T extends object
   ? {
       [P in keyof T]: P extends symbol ? T[P] : UnwrapRef<T[P]>


### PR DESCRIPTION
Actually it caused a type error in my command line, which complained for missing properties:  [Symbol.iterator], [Symbol.unscopables].