### PR TITLE
refactor: use `.mjs` for module by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/vuejs/composition-api.git"
   },
   "main": "./index.js",
-  "module": "./dist/vue-composition-api.esm.js",
+  "module": "./dist/vue-composition-api.mjs",
   "unpkg": "./dist/vue-composition-api.prod.js",
   "jsdelivr": "./dist/vue-composition-api.prod.js",
   "types": "./dist/vue-composition-api.d.ts",


### PR DESCRIPTION
We believe it's a future-proofing move to use the explicit `.mjs` build for modules as it's the standard. Given the downstream libs like `vue-demi` and `@vueuse/core` are already moved to `.mjs` we think it's time for us to make the change. This will be released as v1.3.0.

## Troubleshooting

### `.mjs` can't resolve on Webpack 4

https://github.com/vueuse/vueuse/issues/718

###### Nuxt

```js
// nuxt.config.js

module.exports = {
  build: {
    extend (config) {
      config.module.rules.push({
        test: /\.mjs$/,
        include: /node_modules/,
        type: "javascript/auto"
      })
    }
  }
}
```

###### Vue CLI

```js
// vue.config.js

module.exports = {
  configureWebpack: {
    module: {
      rules: [{
        test: /\.mjs$/,
        include: /node_modules/,
        type: "javascript/auto"
      }]
    }
  }
}
```

### `[vue-composition-api] must call Vue.use(VueCompositionAPI) before using any function`

Make share you have only one version of `@vue/composition-api` installed and resolved to the same version.

###### Vite

https://github.com/vueuse/vue-demi/issues/106#issuecomment-953561344

```js
resolve: {
  alias: [
    { find: /^@vue\/composition-api$/, replacement: '@vue/composition-api/dist/vue-composition-api.mjs' },
  ]
}
```

###### Webpack

```js
resolve: {
  alias: [
    '@vue/composition-api$': '@vue/composition-api/dist/vue-composition-api.mjs'
  ]
}
```
