### PR TITLE
fix(types): defineComponent object format with no props type

### DIFF
--- a/src/component/componentOptions.ts
+++ b/src/component/componentOptions.ts
@@ -88,7 +88,7 @@ export type ComponentOptionsWithArrayProps<
 } & ThisType<ComponentRenderProxy<Props, RawBindings, D, C, M>>
 
 export type ComponentOptionsWithoutProps<
-  Props = unknown,
+  Props = {},
   RawBindings = Data,
   D = Data,
   C extends ComputedOptions = {},

--- a/src/component/defineComponent.ts
+++ b/src/component/defineComponent.ts
@@ -17,8 +17,8 @@ export function defineComponent<
   C extends ComputedOptions = {},
   M extends MethodOptions = {}
 >(
-  options: ComponentOptionsWithoutProps<unknown, RawBindings, D, C, M>
-): VueProxy<unknown, RawBindings, D, C, M>
+  options: ComponentOptionsWithoutProps<{}, RawBindings, D, C, M>
+): VueProxy<{}, RawBindings, D, C, M>
 
 // overload 2: object format with array props declaration
 // props inferred as { [key in PropNames]?: any }

--- a/test/types/defineComponent.spec.ts
+++ b/test/types/defineComponent.spec.ts
@@ -137,7 +137,7 @@ describe('defineComponent', () => {
     const App = defineComponent({
       setup(props, ctx) {
         isTypeEqual<SetupContext, typeof ctx>(true)
-        isTypeEqual<unknown, typeof props>(true)
+        isTypeEqual<{}, typeof props>(true)
         return () => null
       },
     })


### PR DESCRIPTION

see https://github.com/vuejs/vue-next/blob/140f08991727d7c15db907eea5a101979fe390b2/packages/runtime-core/src/apiDefineComponent.ts#L95-L120

```ts
// overload 2: object format with no props
// (uses user defined props interface)
// return type is for Vetur and TSX support
export function defineComponent<
  Props = {},
  RawBindings = {},
  D = {},
  C extends ComputedOptions = {},
  M extends MethodOptions = {},
  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
  E extends EmitsOptions = EmitsOptions,
  EE extends string = string
>(
  options: ComponentOptionsWithoutProps<
    Props,
    RawBindings,
    D,
    C,
    M,
    Mixin,
    Extends,
    E,
    EE
  >
): DefineComponent<Props, RawBindings, D, C, M, Mixin, Extends, E, EE>
```

Vue 3 use `{}` rather than `unknown` when object format with no props.
