### PR TITLE
fix: changing prop causes rerender to lose attributes #840

### DIFF
--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -34,7 +34,7 @@ export function mixin(Vue: VueConstructor) {
       updateTemplateRef(this)
     },
     beforeUpdate() {
-      updateVmAttrs(this as ComponentInstance, this as SetupContext)
+      updateVmAttrs(this as ComponentInstance)
     },
     updated(this: ComponentInstance) {
       updateTemplateRef(this)

--- a/src/utils/vmStateManager.ts
+++ b/src/utils/vmStateManager.ts
@@ -1,9 +1,13 @@
 import { ComponentInstance, Data } from '../component'
+import { SetupContext } from '../runtimeContext'
 
 export interface VfaState {
   refs?: string[]
   rawBindings?: Data
-  attrBindings?: Data
+  attrBindings?: {
+    ctx: SetupContext
+    data: Data
+  }
   slots?: string[]
 }
 


### PR DESCRIPTION
fix https://github.com/vuejs/composition-api/issues/840
This problem is triggered when the user installs the composition API and uses the template method to define that the key of data contains attrs

Like test case description