### PR TITLE
feat(types): allow a generic in App type

### DIFF
--- a/src/apis/createApp.ts
+++ b/src/apis/createApp.ts
@@ -3,7 +3,8 @@ import { VueConstructor } from 'vue/types/umd'
 import { getVueConstructor } from '../runtimeContext'
 import { warn } from '../utils'
 
-export interface App {
+// Has a generic to match Vue 3 API and be type compatible
+export interface App<T = any> {
   config: VueConstructor['config']
   use: VueConstructor['use']
   mixin: VueConstructor['mixin']


### PR DESCRIPTION
This way, `App` type is compatible with Vue 3 while being backwards compatible