### PR TITLE
fix: #874 setup return object with type of Module

### DIFF
--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -115,7 +115,7 @@ export function mixin(Vue: VueConstructor) {
         return activateCurrentInstance(instance, () => bindingFunc())
       }
       return
-    } else if (isPlainObject(binding)) {
+    } else if (isObject(binding)) {
       if (isReactive(binding)) {
         binding = toRefs(binding) as Data
       }


### PR DESCRIPTION
`isPlainObject` is too strict for the returning value of setup function. Sometimes user may `return { ...refs }` in setup function, and `Symbol(Symbol.toStringTag) in refs` (eg: refs is a ESModule object), then `{ ...refs }` will inherit that symbol property, then `isPlainObject({ ...refs }) === false` which may not that intuitive.

Besides, vue3 use `isObject` too. https://github.com/vuejs/vue-next/blob/87c86e4cc2/packages/runtime-core/src/component.ts#L688