### PR TITLE
fix(types): `emit` type in SetupContext

### DIFF
--- a/src/component/componentOptions.ts
+++ b/src/component/componentOptions.ts
@@ -22,10 +22,14 @@ export interface MethodOptions {
   [key: string]: Function
 }
 
-export type SetupFunction<Props, RawBindings = {}> = (
+export type SetupFunction<
+  Props,
+  RawBindings = {},
+  Emits extends EmitsOptions = {}
+> = (
   this: void,
   props: Readonly<Props>,
-  ctx: SetupContext
+  ctx: SetupContext<Emits>
 ) => RawBindings | (() => VNode | null) | void
 
 interface ComponentOptionsBase<
@@ -70,7 +74,7 @@ export type ComponentOptionsWithProps<
 > = ComponentOptionsBase<Props, D, C, M> & {
   props?: PropsOptions
   emits?: Emits & ThisType<void>
-  setup?: SetupFunction<Props, RawBindings>
+  setup?: SetupFunction<Props, RawBindings, Emits>
 } & ThisType<
     ComponentRenderProxy<Props, RawBindings, D, C, M, Mixin, Extends, Emits>
   >
@@ -88,7 +92,7 @@ export type ComponentOptionsWithArrayProps<
 > = ComponentOptionsBase<Props, D, C, M> & {
   props?: PropNames[]
   emits?: Emits & ThisType<void>
-  setup?: SetupFunction<Props, RawBindings>
+  setup?: SetupFunction<Props, RawBindings, Emits>
 } & ThisType<
     ComponentRenderProxy<Props, RawBindings, D, C, M, Mixin, Extends, Emits>
   >
@@ -105,7 +109,7 @@ export type ComponentOptionsWithoutProps<
 > = ComponentOptionsBase<Props, D, C, M> & {
   props?: undefined
   emits?: Emits & ThisType<void>
-  setup?: SetupFunction<Props, RawBindings>
+  setup?: SetupFunction<Props, RawBindings, Emits>
 } & ThisType<
     ComponentRenderProxy<Props, RawBindings, D, C, M, Mixin, Extends, Emits>
   >

--- a/src/runtimeContext.ts
+++ b/src/runtimeContext.ts
@@ -145,7 +145,7 @@ export type ComponentRenderEmitFn<
 
 export type Slots = Readonly<InternalSlots>
 
-export interface SetupContext<E = EmitsOptions> {
+export interface SetupContext<E extends EmitsOptions = {}> {
   attrs: Data
   slots: Slots
   emit: EmitFn<E>

--- a/test-dts/defineComponent-vue2.d.tsx
+++ b/test-dts/defineComponent-vue2.d.tsx
@@ -14,6 +14,10 @@ describe('emits', () => {
       click: (n: number) => typeof n === 'number',
       input: (b: string) => b.length > 1,
     },
+    setup(props, { emit }) {
+      emit('click', 1)
+      emit('input', 'foo')
+    },
     created() {
       this.$emit('click', 1)
       this.$emit('click', 1).$emit('click', 1)


### PR DESCRIPTION
If you define a component with `emits`, then you can type this.$emits

So with this, you get autocompletion and signature validation on `this.$emit`
```ts
  defineComponent({
    emits: {
      click: (n: number) => typeof n === 'number',
      input: (b: string) => b.length > 1,
    },
    created() {
      this.$emit('click', 1)
      this.$emit('input', 'foo')
    },
  })
```

but you don't get the same behavior in the setup function.

```ts
  defineComponent({
    emits: {
      click: (n: number) => typeof n === 'number',
      input: (b: string) => b.length > 1,
    },
    setup(props, { emit ) {
      emit('click', 1)
      emit('input', 'foo')
    },
  })
```

this will work, gives no errors, but also no auto completion or compilation safety with typescript.

This PR is will enable that, so that the emit property of the SetupContext has typed emits.

<img width="586" alt="image" src="https://user-images.githubusercontent.com/136992/149032119-065bca9b-fd68-49fa-9478-39fb2024100d.png">

I don't know if there is a reason why this is not already the behavior of SetupContext, but it seems to be a good addition.
