### PR TITLE
fix(shallowReactive): don't trigger watchers for oldVal === newVal

### DIFF
--- a/src/reactivity/force.ts
+++ b/src/reactivity/force.ts
@@ -1,0 +1,9 @@
+let _isForceTrigger = false
+
+export function isForceTrigger() {
+  return _isForceTrigger
+}
+
+export function setForceTrigger(v: boolean) {
+  _isForceTrigger = v
+}

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -14,6 +14,7 @@ import { isComponentInstance, defineComponentInstance } from '../utils/helper'
 import { RefKey } from '../utils/symbols'
 import { isRef, UnwrapRef } from './ref'
 import { rawSet, accessModifiedSet } from '../utils/sets'
+import { isForceTrigger } from './force'
 
 export function isRaw(obj: any): boolean {
   return Boolean(
@@ -213,8 +214,9 @@ export function shallowReactive(obj: any) {
         return value
       },
       set: function setterHandler(newVal: any) {
+        if (getter && !setter) return
         const value = getter ? getter.call(obj) : val
-        if (newVal === value || (getter && !setter)) return
+        if (!isForceTrigger() && value === newVal) return
         if (setter) {
           setter.call(obj, newVal)
         } else {

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -213,7 +213,8 @@ export function shallowReactive(obj: any) {
         return value
       },
       set: function setterHandler(newVal: any) {
-        if (getter && !setter) return
+        const value = getter ? getter.call(obj) : val
+        if (newVal === value || (getter && !setter)) return
         if (setter) {
           setter.call(obj, newVal)
         } else {

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -184,7 +184,9 @@ export function shallowRef(raw?: unknown) {
 export function triggerRef(value: any) {
   if (!isRef(value)) return
 
-  value.value = value.value
+  const v = value.value
+  value.value = !v
+  value.value = v
 }
 
 export function proxyRefs<T extends object>(

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -3,6 +3,7 @@ import { proxy, isPlainObject, warn, def } from '../utils'
 import { reactive, isReactive, shallowReactive } from './reactive'
 import { readonlySet } from '../utils/sets'
 import { set } from './set'
+import { setForceTrigger } from './force'
 
 declare const _refBrand: unique symbol
 export interface Ref<T = any> {
@@ -184,9 +185,9 @@ export function shallowRef(raw?: unknown) {
 export function triggerRef(value: any) {
   if (!isRef(value)) return
 
-  const v = value.value
-  value.value = !v
-  value.value = v
+  setForceTrigger(true)
+  value.value = value.value
+  setForceTrigger(false)
 }
 
 export function proxyRefs<T extends object>(

--- a/test/v3/reactivity/ref.spec.ts
+++ b/test/v3/reactivity/ref.spec.ts
@@ -250,9 +250,27 @@ describe('reactivity/ref', () => {
     expect(dummy).toBe(1) // should not trigger yet
 
     // force trigger
-    // sref.value = sref.value;
     triggerRef(sref)
     expect(dummy).toBe(2)
+  })
+
+  test('shallowRef noop when assignment is the same', () => {
+    const sref = shallowRef(1)
+    let calls = 0
+    watchEffect(
+      () => {
+        sref.value
+        calls++
+      },
+      { flush: 'sync' }
+    )
+    expect(calls).toBe(1)
+
+    sref.value = 2
+    expect(calls).toBe(2)
+
+    sref.value = 2
+    expect(calls).toBe(2)
   })
 
   test('isRef', () => {


### PR DESCRIPTION
Hi, I found another situation that's causing me infinite loops with this library but not with Vue 3