### PR TITLE
fix: markRaw in watch

### DIFF
--- a/src/apis/watch.ts
+++ b/src/apis/watch.ts
@@ -20,6 +20,7 @@ import {
   WatcherPostFlushQueueKey,
 } from '../utils/symbols'
 import { getCurrentScopeVM } from './effectScope'
+import { rawSet } from '../utils/sets'
 
 export type WatchEffect = (onInvalidate: InvalidateCbRegistrator) => void
 
@@ -475,7 +476,7 @@ export function watch<T = any>(
 }
 
 function traverse(value: unknown, seen: Set<unknown> = new Set()) {
-  if (!isObject(value) || seen.has(value)) {
+  if (!isObject(value) || seen.has(value) || rawSet.has(value)) {
     return value
   }
   seen.add(value)

--- a/test/apis/watch.spec.js
+++ b/test/apis/watch.spec.js
@@ -7,6 +7,7 @@ const {
   set,
   computed,
   nextTick,
+  markRaw,
 } = require('../../src')
 const { mockWarn } = require('../helpers')
 
@@ -175,6 +176,34 @@ describe('api/watch', () => {
         expect(spy).toHaveBeenLastCalledWith(vm.a, oldA)
       })
       .then(done)
+  })
+
+  it('markRaw', (done) => {
+    const nestedState = ref(100)
+
+    const state = ref({
+      rawValue: markRaw({
+        nestedState,
+      }),
+    })
+
+    watch(
+      state,
+      () => {
+        spy()
+      },
+      { deep: true }
+    )
+
+    function changeRawValue() {
+      nestedState.value = Math.random()
+    }
+
+    changeRawValue()
+
+    waitForUpdate(() => {
+      expect(spy).not.toBeCalled()
+    }).then(done)
   })
 
   it('should flush after render (immediate=false)', (done) => {


### PR DESCRIPTION
Currently `watch` with `deep:true` will ignore object that marked with `markRaw`.
This fix makes it align with the latest [vue3 behavior](https://codesandbox.io/s/lucid-rgb-z2h0x?file=/src/App.vue).