### PR TITLE
fix(types): optional Boolean props as default props

### DIFF
--- a/src/component/componentProps.ts
+++ b/src/component/componentProps.ts
@@ -76,7 +76,19 @@ export type ExtractPropTypes<O> = O extends object
   : { [K in string]: any }
 
 type DefaultKeys<T> = {
-  [K in keyof T]: T[K] extends { default: any } ? K : never
+  [K in keyof T]: T[K] extends
+    | {
+        default: any
+      }
+    | BooleanConstructor
+    | { type: BooleanConstructor }
+    ? T[K] extends {
+        type: BooleanConstructor
+        required: true
+      }
+      ? never
+      : K
+    : never
 }[keyof T]
 
 // extract props which defined with default from prop options


### PR DESCRIPTION
Ported from [vue-next](https://github.com/vuejs/core/blob/5898629d723e82b68e9b17b91bf8b1a8390a3912/packages/runtime-core/src/componentProps.ts#L91)

Volar show type error for missing optional boolean without this.