### PR TITLE
refactor: obj[key] have already triggered the getter

### DIFF
--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -208,14 +208,13 @@ export function shallowReactive(obj: any) {
 
     proxy(observed, key, {
       get: function getterHandler() {
-        const value = getter ? getter.call(obj) : val
         ob.dep?.depend()
-        return value
+        return val
       },
       set: function setterHandler(newVal: any) {
         if (getter && !setter) return
-        const value = getter ? getter.call(obj) : val
-        if (!isForceTrigger() && value === newVal) return
+
+        if (!isForceTrigger() && val === newVal) return
         if (setter) {
           setter.call(obj, newVal)
         } else {


### PR DESCRIPTION
`let val = obj[key]` have already triggerd the getter; So `const value = getter ? getter.call(obj) : val` is redundant