### PR TITLE
fix(inject): allow default value to be undefined

### DIFF
--- a/src/apis/inject.ts
+++ b/src/apis/inject.ts
@@ -76,7 +76,7 @@ export function inject(
     return val
   }
 
-  if (defaultValue === undefined && __DEV__) {
+  if (arguments.length > 1 && __DEV__) {
     warn(`Injection "${String(key)}" not found`, vm)
   }
 

--- a/src/apis/inject.ts
+++ b/src/apis/inject.ts
@@ -74,13 +74,11 @@ export function inject(
   const val = resolveInject(key, vm)
   if (val !== NOT_FOUND) {
     return val
+  } else if (arguments.length > 1) {
+    return treatDefaultAsFactory && isFunction(defaultValue)
+      ? defaultValue()
+      : defaultValue
+  } else if (__DEV__) {
+    warn(`Injection "${String(key)}" not found.`, vm)
   }
-
-  if (arguments.length > 1 && __DEV__) {
-    warn(`Injection "${String(key)}" not found`, vm)
-  }
-
-  return treatDefaultAsFactory && isFunction(defaultValue)
-    ? defaultValue()
-    : defaultValue
 }

--- a/test/apis/inject.spec.js
+++ b/test/apis/inject.spec.js
@@ -166,24 +166,4 @@ describe('Hooks provide/inject', () => {
     }).$mount()
     expect(fn).toHaveBeenCalled()
   })
-
-  it('should not warn when default value is undefined', () => {
-    let injected
-    new Vue({
-      template: `<child/>`,
-      components: {
-        child: {
-          template: `<div>{{ msg }}</div>`,
-          setup() {
-            injected = inject('foo', undefined)
-            return {
-              injected,
-            }
-          },
-        },
-      },
-    }).$mount()
-
-    expect(`injection "foo" not found`).not.toHaveBeenWarned()
-  })
 })

--- a/test/apis/inject.spec.js
+++ b/test/apis/inject.spec.js
@@ -166,4 +166,24 @@ describe('Hooks provide/inject', () => {
     }).$mount()
     expect(fn).toHaveBeenCalled()
   })
+
+  it('should not warn when default value is undefined', () => {
+    let injected
+    new Vue({
+      template: `<child/>`,
+      components: {
+        child: {
+          template: `<div>{{ msg }}</div>`,
+          setup() {
+            injected = inject('foo', undefined)
+            return {
+              injected,
+            }
+          },
+        },
+      },
+    }).$mount()
+
+    expect(`injection "foo" not found`).not.toHaveBeenWarned()
+  })
 })

--- a/test/v3/runtime-core/apiInject.spec.ts
+++ b/test/v3/runtime-core/apiInject.spec.ts
@@ -239,7 +239,7 @@ describe('api: provide/inject', () => {
     const root = document.createElement('div')
     const vm = createApp(Provider).mount(root)
     expect(vm.$el.outerHTML).toBe(`<div></div>`)
-    expect(`[Vue warn]: Injection "foo" not found`).toHaveBeenWarned()
+    expect(`[Vue warn]: Injection "foo" not found.`).toHaveBeenWarned()
   })
 
   it('should warn unfound w/ injectionKey is undefined', () => {
@@ -276,5 +276,32 @@ describe('api: provide/inject', () => {
     const root = document.createElement('div')
     const vm = createApp(Comp).mount(root)
     expect(vm.$el.outerHTML).toBe(`<div>foo</div>`)
+  })
+
+  it('should not warn when default value is undefined', () => {
+    const Provider = {
+      setup() {
+        provide('foo', undefined)
+        return () => h(Middle)
+      },
+    }
+
+    const Middle = {
+      setup() {
+        return () => h(Consumer)
+      },
+    }
+
+    const Consumer = {
+      setup() {
+        const foo = inject('foo')
+        return () => h('div', foo as unknown as string)
+      },
+    }
+
+    const root = document.createElement('div')
+    const vm = createApp(Provider).mount(root)
+    expect(vm.$el.outerHTML).toBe(`<div></div>`)
+    expect(`injection "foo" not found.`).not.toHaveBeenWarned()
   })
 })


### PR DESCRIPTION
Matches vue 3's implementation on provide/inject where passing `undefined` as a defaultValue silences the error

https://github.com/vuejs/core/pull/894/files