### PR TITLE
fix(types): add `Date` to `BaseTypes`

### DIFF
--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -34,7 +34,7 @@ type WeakCollections = WeakMap<any, any> | WeakSet<any>
 // corner case when use narrows type
 // Ex. type RelativePath = string & { __brand: unknown }
 // RelativePath extends object -> true
-type BaseTypes = string | number | boolean | Node | Window
+type BaseTypes = string | number | boolean | Node | Window | Date
 
 export type ShallowUnwrapRef<T> = {
   [K in keyof T]: T[K] extends Ref<infer V> ? V : T[K]


### PR DESCRIPTION
Add `Date` to BaseTypes to prevent type resolve mismatch.

```
Argument of type 'string | { toString: () => string; toDateString: () => string; toTimeString: () => string; toLocaleString: { (): string; (locales?: string | string[] | undefined, options?: DateTimeFormatOptions | undefined): string; }; ... 38 more ...; toJSON: (key?: any) => string; }' is not assignable to parameter of type 'string | Date'.```