### PR TITLE
fix(types): add types to package export

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "exports": {
     ".": {
       "import": "./dist/vue-composition-api.mjs",
+      "types": "./dist/vue-composition-api.d.ts",
       "require": "./index.js"
     },
     "./*": "./*"


### PR DESCRIPTION
Resolve type inference problem when `moduleResolution` is  `NodeNext`.
https://stackblitz.com/edit/typescript-jldbyo?file=tsconfig.json,index.ts,package.json