### PR TITLE
fix(types): function constructor should be a Function

### DIFF
--- a/src/component/componentProps.ts
+++ b/src/component/componentProps.ts
@@ -59,7 +59,7 @@ type InferPropType<T> = T extends null
         ? boolean
           : T extends DateConstructor | { type: DateConstructor}
             ? Date
-              : T extends FunctionConstructor
+              : T extends FunctionConstructor | { type: FunctionConstructor }
                 ? Function
                 : T extends Prop<infer V, infer D>
                   ? unknown extends V


### PR DESCRIPTION
# conclusion
fix prop type is Function, but setup function infer to a never type.

[issue link](https://github.com/vuejs/composition-api/issues/971)